### PR TITLE
Validate token format and check for root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: python
-sudo: required
 python:
   - "2.7"
 install: pip install flake8 tox
 script: tox
-addons:
-  apt:
-    packages:
-      - gnupg

--- a/tests/test_ubuntu_advantage.py
+++ b/tests/test_ubuntu_advantage.py
@@ -36,6 +36,18 @@ class UbuntuAdvantageTest(TestWithFixtures):
             ubuntu_advantage.get_list_file(),
             '/etc/apt/sources.list.d/ubuntu-esm-precise.list')
 
+    def test_valid_token_valid(self):
+        """valid_token returns True if the token has a valid format."""
+        self.assertTrue(ubuntu_advantage.valid_token('foo:bar'))
+
+    def test_valid_token_invalid_no_colon(self):
+        """valid_token returns False if the token contains no colon."""
+        self.assertFalse(ubuntu_advantage.valid_token('foo-bar'))
+
+    def test_valid_token_invalid_too_many_colon(self):
+        """valid_token returns False if the token contains many colons."""
+        self.assertFalse(ubuntu_advantage.valid_token('foo:bar:baz'))
+
     def test_write_list_file(self):
         """write_list_file writes the sources.list.d file."""
         list_file = self.tempdir.join('sample.list')

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -85,7 +85,7 @@ def get_args(argv):
     action_enable = subparsers.add_parser(
         'enable-esm', help='enable the ESM repository')
     action_enable.add_argument(
-        'token', help='the user token, in the form "<user>:<password>"')
+        'token', help='the user token, in the form "user:password"')
 
     subparsers.add_parser('disable-esm', help='disable the ESM repository')
 
@@ -139,13 +139,26 @@ def import_gpg_key(print=print):
         raise APTAddGPGKeyFailed(err.strip())
 
 
+def valid_token(token):
+    """Return whether the format of the provided token is valid."""
+    return len(token.split(':')) == 2
+
+
 def main(argv=None):
     args = get_args(argv)
+
+    if os.geteuid() != 0:
+        exit('This command must be run as root (try using sudo)')
+
     if args.action == 'enable-esm':
+        if not valid_token(args.token):
+            exit(
+                'Token format is invalid, it should be in the form'
+                ' "user:password"')
         try:
             enable_esm(args.token)
         except APTAddGPGKeyFailed as error:
-            print('Failed to enable ESM archive: {}'.format(error))
+            exit('Failed to enable ESM archive: {}'.format(error))
     if args.action == 'disable-esm':
         disable_esm()
 


### PR DESCRIPTION
Fixes #4 and #5:

- validate the format of the token
- check that the command is run as root