### PR TITLE
Add dep8 tests, should work for non-precise releases now.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ubuntu-advantage-tools (2) precise; urgency=medium
+
+  * ubuntu-advantage & /etc/update-motd.d/99-esm now quiet on non-precise
+    release.
+  * Add simple dep8 tests.
+
+ -- David Britton <david.britton@canonical.com>  Wed, 28 Jun 2017 20:43:25 -0600
+
 ubuntu-advantage-tools (1) precise; urgency=medium
 
   * Initial Release. LP: #1686183

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/CanonicalLtd/ubuntu-advantage-script
 
 Package: ubuntu-advantage-tools
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${misc:Depends}
 Description: Ubuntu Advantage tools for ESM
  This package ships Ubuntu Advantage subscription management tools.
  .

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,2 +1,2 @@
-Tests: usage
+Tests: usage, update-motd-run
 Restrictions: allow-stderr

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,2 @@
+Tests: usage
+Restrictions: allow-stderr

--- a/debian/tests/update-motd-run
+++ b/debian/tests/update-motd-run
@@ -1,0 +1,18 @@
+#/bin/sh
+
+set -ex
+
+# virgin system should not have esm enabled
+codename=`lsb_release -cs`
+motd_text=`/bin/sh /etc/update-motd.d/99-esm`
+
+if [ "$codename" == "precise" ]; then
+	echo $motd_text | grep "This Ubuntu 12.04 LTS system is past"
+else
+	[ "$motd_text" == "" ] \
+		|| ( echo "motd should be empty on $codename" && exit 1 )
+	
+fi
+
+# help output should contain 'enable-esm' in it, and should be on stderr
+ubuntu-advantage --help 2>&1 >/dev/null | grep enable-esm

--- a/debian/tests/update-motd-run
+++ b/debian/tests/update-motd-run
@@ -11,7 +11,7 @@ if [ "$codename" == "precise" ]; then
 else
 	[ "$motd_text" == "" ] \
 		|| ( echo "motd should be empty on $codename" && exit 1 )
-	
+
 fi
 
 # help output should contain 'enable-esm' in it, and should be on stderr

--- a/debian/tests/usage
+++ b/debian/tests/usage
@@ -1,0 +1,9 @@
+#/bin/sh
+
+set -ex
+
+# virgin system should not have esm enabled
+! ubuntu-advantage is-esm-enabled 
+
+# help output should contain 'enable-esm' in it, and should be on stderr
+ubuntu-advantage --help 2>&1 >/dev/null | grep enable-esm

--- a/tests.py
+++ b/tests.py
@@ -27,6 +27,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.make_fake_binary('apt-get')
         self.make_fake_binary('apt-method-https')
         self.make_fake_binary('id', command='echo 0')
+        self.make_fake_binary('lsb_release', command='echo precise')
 
     def make_fake_binary(self, binary, command='true'):
         path = self.bin_dir / binary

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -2,9 +2,10 @@
 
 SCRIPTNAME=$(basename "$0")
 
+SERIES=`lsb_release -cs`
 REPO_URL="esm.ubuntu.com"
 REPO_KEY_FILE="ubuntu-esm-keyring.gpg"
-REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-precise.list"}
+REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
 APT_KEYS_DIR=${APT_KEYS_DIR:-"/etc/apt/trusted.gpg.d"}
 APT_METHOD_HTTPS=${APT_METHOD_HTTPS:="/usr/lib/apt/methods/https"}
@@ -12,8 +13,8 @@ APT_METHOD_HTTPS=${APT_METHOD_HTTPS:="/usr/lib/apt/methods/https"}
 
 write_list_file() {
     cat > "$REPO_LIST" <<EOF
-deb https://${1}@${REPO_URL}/ubuntu precise main
-# deb-src https://${1}@${REPO_URL}/ubuntu precise main
+deb https://${1}@${REPO_URL}/ubuntu ${SERIES} main
+# deb-src https://${1}@${REPO_URL}/ubuntu ${SERIES} main
 EOF
 }
 

--- a/update-motd.d/99-esm
+++ b/update-motd.d/99-esm
@@ -1,14 +1,21 @@
 #!/bin/sh
 
+SERIES=$(lsb_release -cs)
+DESCRIPTION=$(lsb_release -ds)
+
+if [ "$SERIES" != "precise" ]; then
+	exit 0
+fi
+
 if ubuntu-advantage is-esm-enabled; then
     cat <<EOF
-This Ubuntu 12.04 system is configured to receive extended security updates
+This ${DESCRIPTION} system is configured to receive extended security updates
 from Canonical:
  * https://www.ubuntu.com/esm
 EOF
 else
     cat <<EOF
-This Ubuntu 12.04 LTS system is past its End of Life, and is no longer
+This ${DESCRIPTION} system is past its End of Life, and is no longer
 receiving security updates.  To protect the integrity of this system, it’s
 critical that you enable Extended Security Maintenance updates:
  * https://www.ubuntu.com/esm


### PR DESCRIPTION
Scripts now variable-ized to install correctly on >= precise.  Script should be entirely silent on non precise releases now.

To test:

```
autopkgtest-build-lxd ubuntu:<series>
autopkgtest . --- lxd ubuntu:<series>
```
