### PR TITLE
Install ca-certificates (Fixes #25).

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,18 @@ To disable the archive, run:
 ```bash
 $ sudo ubuntu-advantage disable-esm
 ```
+
+## Testing
+
+Unit tests & lint:
+
+```bash
+$ tox
+```
+
+Dep8 Tests:
+
+```
+# To test on 16.04:
+$ autopkgtest --shell-fail . -- lxd ubuntu:xenial
+```

--- a/debian/tests/update-motd-run
+++ b/debian/tests/update-motd-run
@@ -4,10 +4,11 @@ set -ex
 
 # virgin system should not have esm enabled
 codename=`lsb_release -cs`
+description=`lsb_release -ds`
 motd_text=`/bin/sh /etc/update-motd.d/99-esm`
 
 if [ "$codename" == "precise" ]; then
-	echo $motd_text | grep "This Ubuntu 12.04 LTS system is past"
+	echo $motd_text | grep "This ${description} system is past"
 else
 	[ "$motd_text" == "" ] \
 		|| ( echo "motd should be empty on $codename" && exit 1 )

--- a/tests.py
+++ b/tests.py
@@ -19,6 +19,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.keyrings_dir = Path(tempdir.join('keyrings'))
         self.trusted_gpg_dir = Path(tempdir.join('trusted.gpg.d'))
         self.apt_method_https = self.bin_dir / 'apt-method-https'
+        self.ca_certificates = self.bin_dir / 'update-ca-certificates'
         # setup directories and files
         self.bin_dir.mkdir()
         self.keyrings_dir.mkdir()
@@ -26,6 +27,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         (self.keyrings_dir / 'ubuntu-esm-keyring.gpg').write_text('GPG key')
         self.make_fake_binary('apt-get')
         self.make_fake_binary('apt-method-https')
+        self.make_fake_binary('update-ca-certificates')
         self.make_fake_binary('id', command='echo 0')
         self.make_fake_binary('lsb_release', command='echo precise')
 
@@ -44,7 +46,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'REPO_LIST': str(self.repo_list),
             'KEYRINGS_DIR': str(self.keyrings_dir),
             'APT_KEYS_DIR': str(self.trusted_gpg_dir),
-            'APT_METHOD_HTTPS': str(self.apt_method_https)}
+            'APT_METHOD_HTTPS': str(self.apt_method_https),
+            'CA_CERTIFICATES': str(self.ca_certificates)}
         process = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         process.wait()
@@ -97,6 +100,23 @@ class UbuntuAdvantageTest(TestWithFixtures):
     def test_enable_install_apt_transport_https_fails(self):
         """Stderr is printed if apt-transport-https install fails."""
         self.apt_method_https.unlink()
+        self.make_fake_binary('apt-get', command='echo failed >&2; false')
+        process = self.script('enable-esm', 'user:pass')
+        self.assertEqual(1, process.returncode)
+        self.assertIn('failed', process.stderr)
+
+    def test_enable_install_ca_certificates(self):
+        """The ca-certificates package is installed if it's not."""
+        self.ca_certificates.unlink()
+        process = self.script('enable-esm', 'user:pass')
+        self.assertEqual(0, process.returncode)
+        self.assertIn(
+            'Installing missing dependency ca-certificates',
+            process.stdout)
+
+    def test_enable_install_ca_certificates__fails(self):
+        """Stderr is printed if ca-certificates install fails."""
+        self.ca_certificates.unlink()
         self.make_fake_binary('apt-get', command='echo failed >&2; false')
         process = self.script('enable-esm', 'user:pass')
         self.assertEqual(1, process.returncode)

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -2,13 +2,14 @@
 
 SCRIPTNAME=$(basename "$0")
 
-SERIES=`lsb_release -cs`
+SERIES=$(lsb_release -cs)
 REPO_URL="esm.ubuntu.com"
 REPO_KEY_FILE="ubuntu-esm-keyring.gpg"
 REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
 APT_KEYS_DIR=${APT_KEYS_DIR:-"/etc/apt/trusted.gpg.d"}
 APT_METHOD_HTTPS=${APT_METHOD_HTTPS:="/usr/lib/apt/methods/https"}
+CA_CERTIFICATES=${CA_CERTIFICATES:="/usr/sbin/update-ca-certificates"}
 
 
 write_list_file() {
@@ -25,6 +26,10 @@ enable_esm() {
     if [ ! -f "$APT_METHOD_HTTPS" ]; then
         echo 'Installing missing dependency apt-transport-https'
         apt-get install -y apt-transport-https >/dev/null
+    fi
+    if [ ! -f "$CA_CERTIFICATES" ]; then
+        echo 'Installing missing dependency ca-certificates'
+        apt-get install -y ca-certificates >/dev/null
     fi
     echo 'Running apt-get update...'
     apt-get update >/dev/null


### PR DESCRIPTION
- Add testing instructions to README
- unit tests
- Fix dep8 text matching issue on precise.