### PR TITLE
ubuntu-advantage livepatch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,44 @@
 
 [![Build Status](https://travis-ci.org/CanonicalLtd/ubuntu-advantage-script.svg?branch=master)](https://travis-ci.org/CanonicalLtd/ubuntu-advantage-script)
 
-Script to enable the Ubuntu ESM (Extended Security Maintenance) archive for Precise.
+This tool is used to enable or disable specific Ubuntu Advantage offerings from Canonical.
 
 
-## Enabling the ESM archive
+## The ESM archive
+Ubuntu Extended Security Maintenance archive. See https://ubuntu.com/esm for more information.
 
 To enable the archive, run:
 
 ```bash
-$ sudo ubuntu-advantage enable-esm <token>
+$ sudo ubuntu-advantage enable-esm token
 ```
 
-where the `token` is in the form `<user>:<password>`.
-
-
-## Disabling the ESM archive
+where the `token` is in the form `user:password`.
 
 To disable the archive, run:
 
 ```bash
 $ sudo ubuntu-advantage disable-esm
 ```
+
+## Livepatch (Canonical Livepatch Service)
+Managed live kernel patching. For more information, visit https://www.ubuntu.com/server/livepatch
+
+To enable live patching on your system, run:
+
+```bash
+$ sudo ubuntu-advantage enable-livepatch token
+```
+
+The token can be obtained by visiting https://ubuntu.com/livepatch
+
+To disable livepatch, run:
+
+```bash
+$ sudo ubuntu-advantage disable-livepatch
+```
+
+If you also want to remove the canonical-livepatch snap, you can pass the `-r` option to `disable-livepatch`.
 
 ## Testing
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-advantage-tools (3~1) xenial; urgency=medium
+
+  * enable-livepatch
+
+ -- Andreas Hasenack <andreas@canonical.com>  Thu, 03 Aug 2017 16:25:47 -0300
+
 ubuntu-advantage-tools (2) trusty; urgency=medium
 
   * ubuntu-advantage & /etc/update-motd.d/99-esm now build, run and are quiet

--- a/tests.py
+++ b/tests.py
@@ -8,6 +8,69 @@ from fixtures import TestWithFixtures, TempDir
 
 ProcessResult = namedtuple('ProcessResult', ['returncode', 'stdout', 'stderr'])
 
+SNAP_LIVEPATCH_INSTALLED = """#!/bin/sh
+if [ "$1" = "list" ]; then
+    cat <<EOF
+Name                 Version  Rev  Developer  Notes
+canonical-livepatch  7        22   canonical  -
+EOF
+elif [ "$1" = "install" ]; then
+    cat <<EOF
+snap "canonical-livepatch" is already installed, see "snap refresh --help"
+EOF
+elif [ "$1" = "remove" ]; then
+    echo "canonical-livepatch removed"
+fi
+exit 0
+"""
+
+SNAP_LIVEPATCH_NOT_INSTALLED = """#!/bin/sh
+if [ "$1" = "list" ]; then
+    cat <<EOF
+error: no matching snaps installed
+EOF
+    exit 1
+elif [ "$1" = "install" ]; then
+    cat <<EOF
+canonical-livepatch 7 from 'canonical' installed
+EOF
+    exit 0
+fi
+"""
+
+LIVEPATCH_ENABLED = """#!/bin/sh
+if [ "$1" = "status" ]; then
+    cat <<EOF
+kernel: 4.4.0-87.110-generic
+fully-patched: true
+version: "27.3"
+EOF
+elif [ "$1" = "enable" ]; then
+    echo -n "2017/08/04 18:03:47 Error executing enable?auth-token="
+    echo "deafbeefdeadbeefdeadbeefdeadbeef."
+    echo -n "Machine-token already exists! Please use 'disable' to delete "
+    echo "existing machine-token."
+elif [ "$1" = "disable" ]; then
+    echo -n "Successfully disabled device. Removed machine-token: "
+    echo "deadbeefdeadbeefdeadbeefdeadbeef"
+fi
+exit 0
+"""
+
+LIVEPATCH_DISABLED = """#!/bin/sh
+if [ "$1" = "status" ]; then
+    cat <<EOF
+Machine is not enabled. Please run 'sudo canonical-livepatch enable' with the
+token obtained from https://ubuntu.com/livepatch.
+EOF
+    exit 1
+elif [ "$1" = "enable" ]; then
+    echo -n "Successfully enabled device. Using machine-token: "
+    echo "deadbeefdeadbeefdeadbeefdeadbeef"
+fi
+exit 0
+"""
+
 
 class UbuntuAdvantageTest(TestWithFixtures):
 
@@ -20,6 +83,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.trusted_gpg_dir = Path(tempdir.join('trusted.gpg.d'))
         self.apt_method_https = self.bin_dir / 'apt-method-https'
         self.ca_certificates = self.bin_dir / 'update-ca-certificates'
+        self.snapd = self.bin_dir / 'snapd'
         # setup directories and files
         self.bin_dir.mkdir()
         self.keyrings_dir.mkdir()
@@ -30,6 +94,11 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.make_fake_binary('update-ca-certificates')
         self.make_fake_binary('id', command='echo 0')
         self.make_fake_binary('lsb_release', command='echo precise')
+        self.make_fake_binary('snapd')
+        # in our default setup the snap is installed and enabled
+        self.make_fake_binary('snap', command=SNAP_LIVEPATCH_INSTALLED)
+        self.make_fake_binary('canonical-livepatch', command=LIVEPATCH_ENABLED)
+        self.livepatch_token = '0123456789abcdef1234567890abcdef'
 
     def make_fake_binary(self, binary, command='true'):
         path = self.bin_dir / binary
@@ -47,7 +116,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'KEYRINGS_DIR': str(self.keyrings_dir),
             'APT_KEYS_DIR': str(self.trusted_gpg_dir),
             'APT_METHOD_HTTPS': str(self.apt_method_https),
-            'CA_CERTIFICATES': str(self.ca_certificates)}
+            'CA_CERTIFICATES': str(self.ca_certificates),
+            'SNAPD': str(self.snapd)}
         process = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         process.wait()
@@ -59,12 +129,17 @@ class UbuntuAdvantageTest(TestWithFixtures):
         process.stderr.close()
         return result
 
-    def test_run_not_as_root(self):
-        """The script must be run as root."""
+    def test_enable_disable_needs_root(self):
+        """The script must be run as root for enable and disable actions."""
         self.make_fake_binary('id', command='echo 100')
-        process = self.script('enable-esm', 'user:pass')
-        self.assertEqual(2, process.returncode)
-        self.assertIn('This command must be run as root', process.stderr)
+        actions = ['enable-esm', 'disable-esm', 'enable-livepatch',
+                   'disable-livepatch']
+        for action in actions:
+            # we don't need to pass a token for the enable actions since the
+            # root check is before the parameter check
+            process = self.script(action)
+            self.assertEqual(2, process.returncode)
+            self.assertIn('This command must be run as root', process.stderr)
 
     def test_usage(self):
         """Calling the script with no args prints out the usage."""
@@ -72,8 +147,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.assertEqual(1, process.returncode)
         self.assertIn('usage: ubuntu-advantage', process.stderr)
 
-    def test_enable(self):
-        """The script enables the ESM repository."""
+    def test_enable_esm(self):
+        """The enable-esm option enables the ESM repository."""
         process = self.script('enable-esm', 'user:pass')
         self.assertEqual(0, process.returncode)
         self.assertIn('Ubuntu ESM repository enabled', process.stdout)
@@ -88,8 +163,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'Installing missing dependency apt-transport-https',
             process.stdout)
 
-    def test_enable_install_apt_transport_https(self):
-        """The apt-transport-https package is installed if it's not."""
+    def test_enable_esm_install_apt_transport_https(self):
+        """enable-esm installs apt-transport-https if needed."""
         self.apt_method_https.unlink()
         process = self.script('enable-esm', 'user:pass')
         self.assertEqual(0, process.returncode)
@@ -97,7 +172,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'Installing missing dependency apt-transport-https',
             process.stdout)
 
-    def test_enable_install_apt_transport_https_fails(self):
+    def test_enable_esm_install_apt_transport_https_fails(self):
         """Stderr is printed if apt-transport-https install fails."""
         self.apt_method_https.unlink()
         self.make_fake_binary('apt-get', command='echo failed >&2; false')
@@ -105,8 +180,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.assertEqual(1, process.returncode)
         self.assertIn('failed', process.stderr)
 
-    def test_enable_install_ca_certificates(self):
-        """The ca-certificates package is installed if it's not."""
+    def test_enable_esm_install_ca_certificates(self):
+        """enable-esm installs ca-certificates if needed."""
         self.ca_certificates.unlink()
         process = self.script('enable-esm', 'user:pass')
         self.assertEqual(0, process.returncode)
@@ -114,7 +189,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'Installing missing dependency ca-certificates',
             process.stdout)
 
-    def test_enable_install_ca_certificates__fails(self):
+    def test_enable_esm_install_ca_certificates__fails(self):
         """Stderr is printed if ca-certificates install fails."""
         self.ca_certificates.unlink()
         self.make_fake_binary('apt-get', command='echo failed >&2; false')
@@ -122,24 +197,24 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.assertEqual(1, process.returncode)
         self.assertIn('failed', process.stderr)
 
-    def test_enable_missing_token(self):
-        """The token must be specified when enabling the repository."""
+    def test_enable_esm_missing_token(self):
+        """The token must be specified when using enable-esm."""
         process = self.script('enable-esm')
         self.assertEqual(3, process.returncode)
         self.assertIn(
             'Invalid token, it must be in the form "user:password"',
             process.stderr)
 
-    def test_enable_invalid_token(self):
-        """The token must be specified as "user:password"."""
+    def test_enable_esm_invalid_token(self):
+        """The ESM token must be specified as "user:password"."""
         process = self.script('enable-esm', 'foo-bar')
         self.assertEqual(3, process.returncode)
         self.assertIn(
             'Invalid token, it must be in the form "user:password"',
             process.stderr)
 
-    def test_disable(self):
-        """The script disables the ESM repository."""
+    def test_disable_esm(self):
+        """The disable-esm option disables the ESM repository."""
         self.script('enable-esm', 'user:pass')
         process = self.script('disable-esm')
         self.assertEqual(0, process.returncode)
@@ -149,8 +224,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
         keyring_file = self.trusted_gpg_dir / 'ubuntu-esm-keyring.gpg'
         self.assertFalse(keyring_file.exists())
 
-    def test_disable_disabled(self):
-        """If the repo is not enabled, disabling is a no-op."""
+    def test_disable_esm_disabled(self):
+        """If the ESM repo is not enabled, disable-esm is a no-op."""
         process = self.script('disable-esm')
         self.assertEqual(0, process.returncode)
         self.assertIn('Ubuntu ESM repository was not enabled', process.stdout)
@@ -166,3 +241,119 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.make_fake_binary('apt-cache')
         process = self.script('is-esm-enabled')
         self.assertEqual(1, process.returncode)
+
+    def test_livepatch_supported_trusty_xenial_not_precise(self):
+        """Livepatch is supported in trusty and xenial but not precise."""
+        for release in ['trusty', 'xenial']:
+            self.make_fake_binary(
+                'lsb_release', command='echo {}'.format(release))
+            process = self.script('enable-livepatch')
+            # if we get a token error, that means we passed the ubuntu
+            # release check.
+            self.assertEqual(3, process.returncode)
+            self.assertIn('Invalid or missing Livepatch token', process.stderr)
+        # precise is not supported
+        self.make_fake_binary('lsb_release', command='echo precise')
+        process = self.script('enable-livepatch')
+        self.assertEqual(4, process.returncode)
+        self.assertIn('Sorry, but Canonical Livepatch is not supported on '
+                      'precise', process.stderr)
+
+    def test_enable_livepatch_missing_token(self):
+        """The token must be specified when using enable-livepatch."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        process = self.script('enable-livepatch')
+        self.assertEqual(3, process.returncode)
+        self.assertIn('Invalid or missing Livepatch token', process.stderr)
+
+    def test_enable_livepatch_invalid_token(self):
+        """The Livepatch token must be specified as 32 hex chars."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        process = self.script('enable-livepatch', 'invalid:token')
+        self.assertEqual(3, process.returncode)
+        self.assertIn('Invalid or missing Livepatch token', process.stderr)
+
+    def test_enable_livepatch_installs_snapd(self):
+        """enable-livepatch installs snapd if needed."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        self.snapd.unlink()
+        process = self.script('enable-livepatch', self.livepatch_token)
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Installing missing dependency snapd', process.stdout)
+
+    def test_enable_livepatch_installs_snap(self):
+        """enable-livepatch installs the livepatch snap if needed."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        self.make_fake_binary('snap', command=SNAP_LIVEPATCH_NOT_INSTALLED)
+        process = self.script('enable-livepatch', self.livepatch_token)
+        self.assertEqual(0, process.returncode)
+        self.assertIn(
+            'Installing the canonical-livepatch snap', process.stdout)
+
+    def test_is_livepatch_enabled_true(self):
+        """is-livepatch-enabled returns 0 if the service is enabled."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        self.make_fake_binary(
+            'canonical-livepatch', command=LIVEPATCH_ENABLED)
+        process = self.script('is-livepatch-enabled')
+        self.assertEqual(0, process.returncode)
+
+    def test_is_livepatch_enabled_false(self):
+        """is-livepatch-enabled returns 1 if the service is not enabled."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        self.make_fake_binary(
+            'canonical-livepatch', command=LIVEPATCH_DISABLED)
+        process = self.script('is-livepatch-enabled')
+        self.assertEqual(1, process.returncode)
+
+    def test_enable_livepatch_enabled(self):
+        """enable-livepatch when it's already enabled is detected."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        process = self.script('enable-livepatch', self.livepatch_token)
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Livepatch already enabled.', process.stdout)
+
+    def test_enable_livepatch(self):
+        """enable-livepatch enables the livepatch service."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        self.make_fake_binary(
+            'canonical-livepatch', command=LIVEPATCH_DISABLED)
+        process = self.script('enable-livepatch', self.livepatch_token)
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Successfully enabled device. Using machine-token:',
+                      process.stdout)
+
+    def test_disable_livepatch_invalid_remove_snap_option(self):
+        """disable-livepatch complains if given an invalid argument."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        process = self.script('disable-livepatch', '-invalidargument')
+        self.assertEqual(1, process.returncode)
+        self.assertIn('Unknown option "-invalidargument"', process.stderr)
+
+    def test_disable_livepatch_already_disabled(self):
+        """disable-livepatch when it's already disabled is detected."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        self.make_fake_binary(
+            'canonical-livepatch', command=LIVEPATCH_DISABLED)
+        process = self.script('disable-livepatch')
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Livepatch is already disabled.', process.stdout)
+
+    def test_disable_livepatch(self):
+        """disable-livepatch disables the service."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        process = self.script('disable-livepatch')
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Successfully disabled device. Removed machine-token: '
+                      'deadbeefdeadbeefdeadbeefdeadbeef', process.stdout)
+        self.assertIn('Note: the canonical-livepatch snap is still installed',
+                      process.stdout)
+
+    def test_disable_livepatch_removing_snap(self):
+        """disable-livepatch with '-r' will also remove the snap."""
+        self.make_fake_binary('lsb_release', command='echo trusty')
+        process = self.script('disable-livepatch', '-r')
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Successfully disabled device. Removed machine-token: '
+                      'deadbeefdeadbeefdeadbeefdeadbeef', process.stdout)
+        self.assertIn('canonical-livepatch removed', process.stdout)

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -3,6 +3,7 @@
 SCRIPTNAME=$(basename "$0")
 
 SERIES=$(lsb_release -cs)
+LIVEPATCH_SUPPORTED_SERIES="trusty xenial"
 REPO_URL="esm.ubuntu.com"
 REPO_KEY_FILE="ubuntu-esm-keyring.gpg"
 REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
@@ -10,19 +11,60 @@ KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
 APT_KEYS_DIR=${APT_KEYS_DIR:-"/etc/apt/trusted.gpg.d"}
 APT_METHOD_HTTPS=${APT_METHOD_HTTPS:="/usr/lib/apt/methods/https"}
 CA_CERTIFICATES=${CA_CERTIFICATES:="/usr/sbin/update-ca-certificates"}
+SNAPD=${SNAPD:="/usr/lib/snapd/snapd"}
 
 
-write_list_file() {
+install_livepatch_prereqs() {
+    if [ ! -f "$SNAPD" ]; then
+        echo 'Installing missing dependency snapd'
+        apt-get install -y snapd >/dev/null
+    fi
+    if ! snap list canonical-livepatch > /dev/null 2>&1; then
+        echo 'Installing the canonical-livepatch snap.'
+        echo 'This may take a few minutes depending on your bandwidth.'
+        # show output as it has a nice progress bar and isn't too verbose
+        snap install canonical-livepatch
+    fi
+}
+
+enable_livepatch() {
+    install_livepatch_prereqs
+    if ! is_livepatch_enabled; then
+        echo 'Enabling Livepatch with the given token, stand by...'
+        canonical-livepatch enable "$1"
+    else
+        echo 'Livepatch already enabled.'
+    fi
+    echo 'You may use the "canonical-livepatch status" command'
+    echo 'to verify your current patch status.'
+}
+
+disable_livepatch() {
+    if is_livepatch_enabled; then
+        echo 'Disabling Livepatch...'
+        canonical-livepatch disable
+        if [ "$1" = "yes" ]; then
+            echo 'Removing the canonical-livepatch snap...'
+            snap remove canonical-livepatch
+        else
+            echo 'Note: the canonical-livepatch snap is still installed.'
+            echo 'To remove it, run sudo snap remove canonical-livepatch'
+        fi
+    else
+        echo 'Livepatch is already disabled.'
+    fi
+}
+
+write_esm_list_file() {
     cat > "$REPO_LIST" <<EOF
 deb https://${1}@${REPO_URL}/ubuntu ${SERIES} main
 # deb-src https://${1}@${REPO_URL}/ubuntu ${SERIES} main
 EOF
 }
 
-
 enable_esm() {
     cp "${KEYRINGS_DIR}/${REPO_KEY_FILE}" "$APT_KEYS_DIR"
-    write_list_file "$1"
+    write_esm_list_file "$1"
     if [ ! -f "$APT_METHOD_HTTPS" ]; then
         echo 'Installing missing dependency apt-transport-https'
         apt-get install -y apt-transport-https >/dev/null
@@ -35,7 +77,6 @@ enable_esm() {
     apt-get update >/dev/null
     echo 'Ubuntu ESM repository enabled.'
 }
-
 
 disable_esm() {
     if [ -f "$REPO_LIST" ]; then
@@ -53,10 +94,30 @@ is_esm_enabled() {
     apt-cache policy | grep -Fq "$REPO_URL"
 }
 
-validate_token(){
+is_livepatch_enabled() {
+    # it's fine if it fails because the snap isn't installed. It's still
+    # a non-zero return value
+    canonical-livepatch status > /dev/null 2>&1
+}
+
+validate_esm_token(){
     echo "$1" | grep -q '^[^:]\+:[^:]\+$'
 }
 
+validate_livepatch_token() {
+    # the livepatch token is an hex string 32 characters long
+    echo "$1" | grep -q -E '^[0-9a-fA-F]{32}$'
+}
+
+check_livepatch_support() {
+    for s in $LIVEPATCH_SUPPORTED_SERIES; do
+        if [ "$s" = "$SERIES" ]; then
+            return
+        fi
+    done
+    echo "Sorry, but Canonical Livepatch is not supported on $SERIES" >&2
+    exit 4
+}
 
 check_user() {
     if [ "$(id -u)" -ne 0 ]; then
@@ -68,26 +129,65 @@ check_user() {
 
 usage() {
     cat >&2 <<EOF
-usage: ${SCRIPTNAME} [enable-esm|disable-esm]
+usage: ${SCRIPTNAME} <command> [parameters]
 
-Enable or disable the Ubuntu Extended Security Maintenance archive.
+This is a tool that facilitates access to some of Canonical's
+Ubuntu Advantage offerings.
 
-Parameters:
- enable-esm <token>     enable the ESM repository
- disable-esm            disable the ESM repository
+Currently available are:
+- Ubuntu Extended Security Maintenance archive (https://ubuntu.com/esm)
+- Canonical Livepatch Service (https://www.ubuntu.com/server/livepatch)
 
-the <token> argument must be in the form "user:password"
+Commands:
+ enable-esm <token>        enable the ESM repository
+ disable-esm               disable the ESM repository
+ enable-livepatch <token>  enable the Livepatch service
+ disable-livepatch [-r]    disable the Livepatch service. With "-r", the
+                           canonical-livepatch snap will also be removed.
 
 EOF
 }
 
 
 case "$1" in
+    enable-livepatch)
+        check_user
+        check_livepatch_support
+        token="$2"
+        if ! validate_livepatch_token "$token"; then
+            echo 'Invalid or missing Livepatch token' >&2
+            echo 'Please visit https://ubuntu.com/livepatch to obtain a' >&2
+            echo 'Livepatch token.' >&2
+            exit 3
+        fi
+        enable_livepatch "$token"
+        ;;
+
+    disable-livepatch)
+        check_user
+        remove_snap="no"
+        if [ -n "$2" ]; then
+            if [ "$2" = "-r" ]; then
+                remove_snap="yes"
+            else
+                echo "Unknown option \"$2\"" >&2
+                usage
+                exit 1
+            fi
+        fi
+        disable_livepatch "$remove_snap"
+        ;;
+
+    is-livepatch-enabled)
+        # no root needed
+        is_livepatch_enabled
+        ;;
+
     enable-esm)
         check_user
 
         token="$2"
-        if ! validate_token "$token"; then
+        if ! validate_esm_token "$token"; then
             echo 'Invalid token, it must be in the form "user:password"' >&2
             exit 3
         fi

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -1,25 +1,37 @@
 .TH UBUNTU-ADVANTAGE 1  "28 April 2017" "" ""
 .SH NAME
-ubuntu-advantage \- Enable or disable the Ubuntu Extended Security
-Maintenance archive.
+ubuntu-advantage \- Enable or disable Ubuntu Advantage offerings from
+Canonical.
 .SH SYNOPSIS
 .B ubuntu-advantage
-[enable-esm <token>|disable-esm]
+<command> [parameters]
 .SH DESCRIPTION
-This tool is used to enable or disable the Ubuntu Extended Security
-Maintenance archive.
+This tool is used to enable or disable specific Ubuntu Advantage offerings
+from Canonical. The available modules and their commands are described below.
 It must be run with root privileges.
-.PP
-Parameters:
-.RS
+.SH ESM (Extended Security Maintenance)
+Ubuntu Extended Security Maintenance archive. See https://ubuntu.com/esm for
+more information.
 .TP
 .B
-enable-esm <token>
-enable the ESM repository. The <token> argument must be in the form
-"user:password"
+enable-esm \fItoken\fR
+Enable the ESM repository. The \fItoken\fR argument must be in the form
+"user:password".
 .TP
 .B
 disable-esm
-disable the ESM repository
-.RE
-.PP
+Disable the ESM repository.
+
+.SH Livepatch (Canonical Livepatch Service)
+Managed live kernel patching. For more information, visit
+https://www.ubuntu.com/server/livepatch
+.TP
+.B
+enable-livepatch \fI<token>\fR
+Enable the Livepatch service. The \fItoken\fR can be obtained by visiting
+https://ubuntu.com/livepatch
+.TP
+.B
+disable-livepatch \fR[\fB\-r\fR]
+Disable the Livepatch service. If the \fB\-r\fR option is given, the
+canonical-livepatch snap will be removed after the sevice is disabled.

--- a/update-motd.d/99-livepatch
+++ b/update-motd.d/99-livepatch
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+DESCRIPTION=$(lsb_release -ds)
+PATH=/snap/bin:$PATH
+
+[ ! -x /usr/bin/ubuntu-advantage ] && exit 0
+
+if ubuntu-advantage is-livepatch-enabled; then
+    cat <<EOF
+This ${DESCRIPTION} system has Canonical Livepatch enabled.
+EOF
+fi
+echo


### PR DESCRIPTION
This branch adds a set of livepatch commands to the ubuntu-advantage script. It includes:

- tests
- manpage update
- README update
- --help output update
- MOTD script for livepatch
- enable and disable commands for livepatch

About my documentation, help and MOTD content and format, let's not try to get it absolutely right here. Unless something is terribly wrong, let's please have someone from Product give it a pass and then we can change it in a follow-up branch.

Given that ubuntu-advantage will get more and more commands, at some point this script should be perhaps refactored into something resembling an ubuntu-advantage.d/ directory, where all subcommands exist. Let's not do it in this branch, though :)
