### PR TITLE
Check if ubuntu-advantage script is there before calling it (Fixes #28)

### DIFF
--- a/update-motd.d/99-esm
+++ b/update-motd.d/99-esm
@@ -7,6 +7,8 @@ if [ "$SERIES" != "precise" ]; then
 	exit 0
 fi
 
+[ ! -x /usr/bin/ubuntu-advantage ] && exit 0
+
 if ubuntu-advantage is-esm-enabled; then
     cat <<EOF
 This ${DESCRIPTION} system is configured to receive extended security updates


### PR DESCRIPTION
In the ESM update-motd.d script, check if the ubuntu-advantage script is available before calling it.