### PR TITLE
Only display apt output in the case of errors.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-advantage-tools (5) trusty; urgency=medium
+
+  * Only display apt output in the case of errors (Fixes #33).
+
+ -- Andreas Hasenack <andreas@canonical.com>  Tue, 08 Aug 2017 12:41:25 -0300
+
 ubuntu-advantage-tools (4) trusty; urgency=medium
 
   * Check running kernel version before enabling the Livepatch service

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -112,7 +112,7 @@ disable_esm() {
         mv "$REPO_LIST" "${REPO_LIST}.save"
         rm -f "$APT_KEYS_DIR/$REPO_KEY_FILE"
         echo -n 'Running apt-get update... '
-        check_result apt-get update 2>&1
+        check_result apt-get update
         echo 'Ubuntu ESM repository disabled.'
     else
         echo 'Ubuntu ESM repository was not enabled.'

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -14,10 +14,25 @@ CA_CERTIFICATES=${CA_CERTIFICATES:="/usr/sbin/update-ca-certificates"}
 SNAPD=${SNAPD:="/usr/lib/snapd/snapd"}
 KERNEL_VERSION=$(uname -r)
 
+check_result() {
+    local result output
+    result=0
+    output=$("$@" 2>&1) || result=$?
+    if [ "$result" -ne "0" ]; then
+        echo "ERROR"
+        if [ -n "$output" ]; then
+            echo "$output" >&2
+        fi
+        exit $result
+    else
+        echo "OK"
+    fi
+}
+
 install_livepatch_prereqs() {
     if [ ! -f "$SNAPD" ]; then
-        echo 'Installing missing dependency snapd'
-        apt-get install -y snapd >/dev/null
+        echo -n 'Installing missing dependency snapd... '
+        check_result apt-get install -y snapd
     fi
     if ! snap list canonical-livepatch > /dev/null 2>&1; then
         echo 'Installing the canonical-livepatch snap.'
@@ -35,6 +50,7 @@ enable_livepatch() {
             echo 'Enabling Livepatch with the given token, stand by...'
             canonical-livepatch enable "$1"
         else
+            echo
             echo "Your currently running kernel ($KERNEL_VERSION) is too old to"
             echo "support snaps. Version 4.4.0 or higher is needed."
             echo
@@ -79,15 +95,15 @@ enable_esm() {
     cp "${KEYRINGS_DIR}/${REPO_KEY_FILE}" "$APT_KEYS_DIR"
     write_esm_list_file "$1"
     if [ ! -f "$APT_METHOD_HTTPS" ]; then
-        echo 'Installing missing dependency apt-transport-https'
-        apt-get install -y apt-transport-https >/dev/null
+        echo -n 'Installing missing dependency apt-transport-https... '
+        check_result apt-get install -y apt-transport-https
     fi
     if [ ! -f "$CA_CERTIFICATES" ]; then
-        echo 'Installing missing dependency ca-certificates'
-        apt-get install -y ca-certificates >/dev/null
+        echo -n 'Installing missing dependency ca-certificates... '
+        check_result apt-get install -y ca-certificates
     fi
-    echo 'Running apt-get update...'
-    apt-get update >/dev/null
+    echo -n 'Running apt-get update... '
+    check_result apt-get update
     echo 'Ubuntu ESM repository enabled.'
 }
 
@@ -95,8 +111,8 @@ disable_esm() {
     if [ -f "$REPO_LIST" ]; then
         mv "$REPO_LIST" "${REPO_LIST}.save"
         rm -f "$APT_KEYS_DIR/$REPO_KEY_FILE"
-        echo 'Running apt-get update...'
-        apt-get update >/dev/null
+        echo -n 'Running apt-get update... '
+        check_result apt-get update 2>&1
         echo 'Ubuntu ESM repository disabled.'
     else
         echo 'Ubuntu ESM repository was not enabled.'


### PR DESCRIPTION
Collect all the output of apt calls and save the result code. If it indicates there was an error, then display it and exit.

This was mainly done for the trusty case, where apt-get install snapd pulls in a new kernel and that package's postinst prints out a lot of info to stderr. Other packages we might install are cleaner and only output to stderr when there is an error. So while not really needed for these other apt-get calls, I decided to wrap them in the say way for consistency, both in terms of coding and script output.

Previous Trusty output: http://pastebin.ubuntu.com/25271508/
Output with the proposed changes: http://pastebin.ubuntu.com/25271514/