### PR TITLE
Disable tests in package builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ lint:
 	@shellcheck -s dash ubuntu-advantage update-motd.d/*
 
 
-.PHONY: check test lint
+.PHONY: test lint

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+build:
+	@echo Nothing to build.
+
 test:
 	@tox
 
@@ -5,4 +8,4 @@ lint:
 	@shellcheck -s dash ubuntu-advantage update-motd.d/*
 
 
-.PHONY: test lint
+.PHONY: build test lint

--- a/debian/rules
+++ b/debian/rules
@@ -1,3 +1,6 @@
 #!/usr/bin/make -f
 %:
 	dh $@
+
+override_dh_auto_test:
+	@echo "Skipping tests during package builds."


### PR DESCRIPTION
We were even running the tests twice, because of the Makefile: once  as a result of "make", and the second run as a result of "make test" which was found by dh_auto_test.