### PR TITLE
Apt non interactive

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,6 +1,6 @@
 # Fake for commands invoked by the script.
 
-SNAP_LIVEPATCH_INSTALLED = """#!/bin/sh
+SNAP_LIVEPATCH_INSTALLED = """\n
 if [ "$1" = "list" ]; then
     cat <<EOF
 Name                 Version  Rev  Developer  Notes
@@ -16,7 +16,7 @@ fi
 exit 0
 """
 
-SNAP_LIVEPATCH_NOT_INSTALLED = """#!/bin/sh
+SNAP_LIVEPATCH_NOT_INSTALLED = """\n
 if [ "$1" = "list" ]; then
     cat <<EOF
 error: no matching snaps installed
@@ -30,7 +30,7 @@ EOF
 fi
 """
 
-LIVEPATCH_ENABLED = """#!/bin/sh
+LIVEPATCH_ENABLED = """\n
 if [ "$1" = "status" ]; then
     cat <<EOF
 kernel: 4.4.0-87.110-generic
@@ -49,7 +49,7 @@ fi
 exit 0
 """
 
-LIVEPATCH_DISABLED = """#!/bin/sh
+LIVEPATCH_DISABLED = """\n
 if [ "$1" = "status" ]; then
     cat <<EOF
 Machine is not enabled. Please run 'sudo canonical-livepatch enable' with the

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -62,3 +62,13 @@ elif [ "$1" = "enable" ]; then
 fi
 exit 0
 """
+
+APT_GET = """\n
+if [ "$DEBIAN_FRONTEND" != "noninteractive" -o \\
+     -z "$(echo $@ | grep -- '-y')" -o \\
+     -z "$(echo $@ | grep force-confold)" ]; then
+    echo -n "ERROR: apt-get called directly. You must use the " >&2
+    echo "apt_get function.">&2
+    exit 99
+fi
+"""

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -10,6 +10,7 @@ from fixtures import (
     TempDir)
 
 from fakes import (
+    APT_GET,
     SNAP_LIVEPATCH_INSTALLED,
     SNAP_LIVEPATCH_NOT_INSTALLED,
     LIVEPATCH_ENABLED,
@@ -46,6 +47,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
 
     def make_fake_binary(self, binary, command='true'):
         path = self.bin_dir / binary
+        if binary == 'apt-get':
+            command = APT_GET + "\n" + command
         path.write_text('#!/bin/sh\n{}\n'.format(command))
         path.chmod(0o755)
 

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -35,6 +35,11 @@ check_result() {
     fi
 }
 
+apt_get() {
+    DEBIAN_FRONTEND=noninteractive \
+        apt-get -y -o Dpkg::Options::='--force-confold' "$@"
+}
+
 # Whether the current series is among supported ones.
 is_supported_series() {
     local s
@@ -50,7 +55,7 @@ is_supported_series() {
 install_livepatch_prereqs() {
     if [ ! -f "$SNAPD" ]; then
         echo -n 'Installing missing dependency snapd... '
-        check_result apt-get install -y snapd
+        check_result apt_get install snapd
     fi
     if ! snap list canonical-livepatch >/dev/null 2>&1; then
         echo 'Installing the canonical-livepatch snap.'
@@ -113,14 +118,14 @@ enable_esm() {
     write_esm_list_file "$1"
     if [ ! -f "$APT_METHOD_HTTPS" ]; then
         echo -n 'Installing missing dependency apt-transport-https... '
-        check_result apt-get install -y apt-transport-https
+        check_result apt_get install apt-transport-https
     fi
     if [ ! -f "$CA_CERTIFICATES" ]; then
         echo -n 'Installing missing dependency ca-certificates... '
-        check_result apt-get install -y ca-certificates
+        check_result apt_get install ca-certificates
     fi
     echo -n 'Running apt-get update... '
-    check_result apt-get update
+    check_result apt_get update
     echo 'Ubuntu ESM repository enabled.'
 }
 
@@ -129,7 +134,7 @@ disable_esm() {
         mv "$REPO_LIST" "${REPO_LIST}.save"
         rm -f "$APT_KEYS_DIR/$REPO_KEY_FILE"
         echo -n 'Running apt-get update... '
-        check_result apt-get update
+        check_result apt_get update
         echo 'Ubuntu ESM repository disabled.'
     else
         echo 'Ubuntu ESM repository was not enabled.'


### PR DESCRIPTION
Create a wrapper for apt-get that sets options for it to be non-interactive. Change all apt-get calls to use that wrapper, and if apt-get is called directly without setting these options, fail the tests.

I welcome comments about my approach to inject the APT_GET preamble using make_fake_binary(), I kind of felt it was too implicit. Also the error message isn't seen when the test fails, because the exit status is checked first. I could have changed that in all tests, but thought it best to submit this first and get some feedback.