### PR TITLE
[fips] configure_fips() doesn't have a validation mechanism if bootde…

### DIFF
--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -200,7 +200,7 @@ configure_fips() {
     # Note: /boot/efi  does not count
     bootdev=$(awk '!/^\s*#/ && $2 ~ /^\/boot\/?$/ { print $1 }' "$FSTAB")
     fips_params="fips=1"
-    if [ -n "$bootdev" ]; then
+    if [[ -n "$bootdev" && "$bootdev" == "UUID"* ]]; then
         fips_params="$fips_params bootdev=$bootdev"
     fi
 


### PR DESCRIPTION
…v isn't a UUID.

Bug#79

Current code look if a separate /boot partition exist in FSTAB, if nothing is return (nonzero value) it skip the bootdev portion but what if the $bootdev is nonzero and doesn't contain a UUID ?

The first field of /boot line could be a device name in the form of (/dev/sdX,...) or a label (LABEL=Boot).
I think iff UUID is needed, then we should add a validation mechanism.

Signed-off-by: Eric Desrochers eric.desrochers@canonical.com