### PR TITLE
use travis matrix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: python
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
-dist: precise
+
+matrix:
+  include:
+    - os: linux
+      dist: precise
+      python: 3.4
+    - os: linux
+      dist: trusty
+      python: 3.5
+    - os: linux
+      dist: trusty
+      python: 3.6
+      
 install: pip install tox
 script: make test lint
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ matrix:
       dist: trusty
       python: 3.6
       
-install: pip install tox
-script: make test lint
+install: make testdep
+script:
+  - make lint
+  - make test
+
 addons:
   apt:
     sources:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 build:
 	@echo Nothing to build.
 
+testdep:
+	pip install tox
+
 test:
 	@tox -e python
 
@@ -9,4 +12,4 @@ lint:
 	@shellcheck -s dash ubuntu-advantage update-motd.d/*
 
 
-.PHONY: build test lint
+.PHONY: build testdep test lint


### PR DESCRIPTION
Run tests on precise (with python 3.4) and trusty (python 3.5 and 3.6)