### PR TITLE
use shellcheck docker image for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,25 @@
 language: python
+python:
+  - 3.4
+  - 3.6
+dist: precise
+
+services:
+  - docker
 
 matrix:
-  include:
-    - os: linux
-      dist: precise
-      python: 3.4
-    - os: linux
-      dist: trusty
-      python: 3.5
-    - os: linux
-      dist: trusty
-      python: 3.6
-      
-install: make testdep
-script:
-  - make lint
-  - make test
+  fast_finish: true
 
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - shellcheck
+stages:
+  - lint
+  - test
+
+jobs:
+  include:
+    - stage: lint
+      script: make lint/docker
+      python: 3.6
+      dist: trusty
+
+install: make testdep
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+UA_SCRIPTS = ubuntu-advantage $(wildcard modules/*)
+MOTD_SCRIPTS = $(wildcard update-motd.d/*)
+
+
 build:
 	@echo Nothing to build.
 
@@ -9,12 +13,23 @@ test:
 
 lint: lint-py lint-sh
 
+lint/docker: lint-py lint-sh/docker
+
 lint-py:
 	@tox -e lint
 
-lint-sh:
-	@shellcheck -s bash ubuntu-advantage modules/*
-	@shellcheck -s dash update-motd.d/*
+lint-sh: SHELLCHECK = shellcheck
+lint-sh: BASH_SCRIPTS = $(UA_SCRIPTS)
+lint-sh: DASH_SCRIPTS = $(MOTD_SCRIPTS)
+lint-sh: _lint-sh-command
 
+lint-sh/docker: SHELLCHECK = docker run --rm -it -v $(PWD):/repo koalaman/shellcheck
+lint-sh/docker: BASH_SCRIPTS = $(patsubst %,/repo/%,$(UA_SCRIPTS))
+lint-sh/docker: DASH_SCRIPTS = $(patsubst %,/repo/%,$(MOTD_SCRIPTS))
+lint-sh/docker: _lint-sh-command
 
-.PHONY: build testdep test lint lint-py lint-sh
+_lint-sh-command:
+	@$(SHELLCHECK) -s bash $(BASH_SCRIPTS)
+	@$(SHELLCHECK) -s dash $(DASH_SCRIPTS)
+
+.PHONY: build testdep test lint lint/docker lint-py lint-sh lint-sh/docker _lint-sh-command

--- a/modules/apt.sh
+++ b/modules/apt.sh
@@ -78,5 +78,6 @@ _apt_add_auth() {
 _apt_remove_auth() {
     local repo_host="$1"
 
+    # shellcheck disable=SC1117
     sed -i "/^machine ${repo_host}\/ubuntu\/ login/d" "$APT_AUTH_FILE"
 }


### PR DESCRIPTION
- add makefile target to run shellcheck from docker, so it's always the latest (this needs to run on trusty as precise images don't support docker)
- add separate lint Travis stage (which runs before the test one)
- run tests with python 3.4 and 3.6 (both on precise)

This PR depends on #97 