### PR TITLE
Use bash shell instead of dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,14 @@ testdep:
 test:
 	@tox -e python
 
-lint:
+lint: lint-py lint-sh
+
+lint-py:
 	@tox -e lint
-	@shellcheck -s dash ubuntu-advantage modules/* update-motd.d/*
+
+lint-sh:
+	@shellcheck -s bash ubuntu-advantage modules/*
+	@shellcheck -s dash update-motd.d/*
 
 
-.PHONY: build testdep test lint
+.PHONY: build testdep test lint lint-py lint-sh

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 # shellcheck disable=SC2039,SC1090
 
 SCRIPTNAME=$(basename "$0")
@@ -55,6 +55,7 @@ print_status() {
     fi
     echo "livepatch: $livepatch_status"
     if [ "$livepatch_output" ]; then
+        # shellcheck disable=SC2001
         echo "$livepatch_output" | sed 's/^/  /'  # indent output
     fi
 


### PR DESCRIPTION
Since `bash` is marked as `Essential` in Ubuntu (same as `dash`), the change doesn't introduce any new dependency.