### PR TITLE
Refactor enable-* and is-*-enabled commands

### DIFF
--- a/modules/service-esm.sh
+++ b/modules/service-esm.sh
@@ -1,6 +1,6 @@
 # shellcheck disable=SC2034,SC2039
 
-ESM_SERVICE_NAME="Extended Security Maintenance"
+ESM_SERVICE_TITLE="Extended Security Maintenance"
 ESM_SUPPORTED_SERIES="precise"
 ESM_SUPPORTED_ARCHS="ALL"
 

--- a/modules/service-esm.sh
+++ b/modules/service-esm.sh
@@ -1,8 +1,8 @@
-# shellcheck disable=SC2039
+# shellcheck disable=SC2034,SC2039
 
-ESM_SERVICE_NAME="Extended Security Maintenance" # shellcheck disable=SC2034
-ESM_SUPPORTED_SERIES="precise" # shellcheck disable=SC2034
-ESM_SUPPORTED_ARCHS="ALL" # shellcheck disable=SC2034
+ESM_SERVICE_NAME="Extended Security Maintenance"
+ESM_SUPPORTED_SERIES="precise"
+ESM_SUPPORTED_ARCHS="ALL"
 
 ESM_REPO_URL="esm.ubuntu.com"
 ESM_REPO_KEY_FILE="ubuntu-esm-keyring.gpg"

--- a/modules/service-esm.sh
+++ b/modules/service-esm.sh
@@ -36,3 +36,12 @@ esm_disable() {
 esm_is_enabled() {
     apt-cache policy | grep -Fq "$ESM_REPO_URL"
 }
+
+esm_validate_token() {
+    local token="$1"
+
+    if ! validate_user_pass_token "$token"; then
+        error_msg 'Invalid token, it must be in the form "user:password"'
+        return 1
+    fi
+}

--- a/modules/service-esm.sh
+++ b/modules/service-esm.sh
@@ -1,7 +1,8 @@
 # shellcheck disable=SC2039
 
-ESM_SUPPORTED_SERIES="precise"
-ESM_SUPPORTED_ARCHS="ALL"
+ESM_SERVICE_NAME="Extended Security Maintenance" # shellcheck disable=SC2034
+ESM_SUPPORTED_SERIES="precise" # shellcheck disable=SC2034
+ESM_SUPPORTED_ARCHS="ALL" # shellcheck disable=SC2034
 
 ESM_REPO_URL="esm.ubuntu.com"
 ESM_REPO_KEY_FILE="ubuntu-esm-keyring.gpg"
@@ -34,10 +35,4 @@ esm_disable() {
 
 esm_is_enabled() {
     apt-cache policy | grep -Fq "$ESM_REPO_URL"
-}
-
-esm_check_support() {
-    check_service_support \
-        "Extended Security Maintenance" "$ESM_SUPPORTED_SERIES" \
-        "$ESM_SUPPORTED_ARCHS"
 }

--- a/modules/service-fips.sh
+++ b/modules/service-fips.sh
@@ -1,6 +1,6 @@
 # shellcheck disable=SC2034,SC2039
 
-FIPS_SERVICE_NAME="Canonical FIPS 140-2 Modules"
+FIPS_SERVICE_TITLE="Canonical FIPS 140-2 Modules"
 FIPS_SUPPORTED_SERIES="xenial"
 FIPS_SUPPORTED_ARCHS="x86_64 ppc64le s390x"
 

--- a/modules/service-fips.sh
+++ b/modules/service-fips.sh
@@ -54,6 +54,15 @@ fips_check_support() {
     _fips_check_arch
 }
 
+fips_validate_token() {
+    local token="$1"
+
+    if ! validate_user_pass_token "$token"; then
+        error_msg 'Invalid token, it must be in the form "user:password"'
+        return 1
+    fi
+}
+
 _fips_configure() {
     local bootdev fips_params result
 

--- a/modules/service-fips.sh
+++ b/modules/service-fips.sh
@@ -1,8 +1,8 @@
-# shellcheck disable=SC2039
+# shellcheck disable=SC2034,SC2039
 
-FIPS_SERVICE_NAME="Canonical FIPS 140-2 Modules" # shellcheck disable=SC2034
-FIPS_SUPPORTED_SERIES="xenial" # shellcheck disable=SC2034
-FIPS_SUPPORTED_ARCHS="x86_64 ppc64le s390x" # shellcheck disable=SC2034
+FIPS_SERVICE_NAME="Canonical FIPS 140-2 Modules"
+FIPS_SUPPORTED_SERIES="xenial"
+FIPS_SUPPORTED_ARCHS="x86_64 ppc64le s390x"
 
 FIPS_REPO_URL="private-ppa.launchpad.net/ubuntu-advantage/fips"
 FIPS_REPO_KEY_FILE="ubuntu-fips-keyring.gpg"

--- a/modules/service-fips.sh
+++ b/modules/service-fips.sh
@@ -1,7 +1,8 @@
 # shellcheck disable=SC2039
 
-FIPS_SUPPORTED_SERIES="xenial"
-FIPS_SUPPORTED_ARCHS="x86_64 ppc64le s390x"
+FIPS_SERVICE_NAME="Canonical FIPS 140-2 Modules" # shellcheck disable=SC2034
+FIPS_SUPPORTED_SERIES="xenial" # shellcheck disable=SC2034
+FIPS_SUPPORTED_ARCHS="x86_64 ppc64le s390x" # shellcheck disable=SC2034
 
 FIPS_REPO_URL="private-ppa.launchpad.net/ubuntu-advantage/fips"
 FIPS_REPO_KEY_FILE="ubuntu-fips-keyring.gpg"

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -1,8 +1,8 @@
-# shellcheck disable=SC2039
+# shellcheck disable=SC2034,SC2039
 
-LIVEPATCH_SERVICE_NAME="Canonical Livepatch" # shellcheck disable=SC2034
-LIVEPATCH_SUPPORTED_SERIES="trusty xenial" # shellcheck disable=SC2034
-LIVEPATCH_SUPPORTED_ARCHS="x86_64" # shellcheck disable=SC2034
+LIVEPATCH_SERVICE_NAME="Canonical Livepatch"
+LIVEPATCH_SUPPORTED_SERIES="trusty xenial"
+LIVEPATCH_SUPPORTED_ARCHS="x86_64"
 
 livepatch_enable() {
     local token="$1"

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -46,9 +46,8 @@ livepatch_disable() {
 }
 
 livepatch_is_enabled() {
-    # it's fine if it fails because the snap isn't installed. It's still
-    # a non-zero return value
-    canonical-livepatch status >/dev/null 2>&1
+    # Explicitly return 1 for the case where the command is not found.
+    canonical-livepatch status >/dev/null 2>&1 || return 1
 }
 
 livepatch_check_support() {

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -7,7 +7,7 @@ LIVEPATCH_SUPPORTED_ARCHS="x86_64" # shellcheck disable=SC2034
 livepatch_enable() {
     local token="$1"
 
-    _install_livepatch_prereqs
+    _livepatch_install_prereqs
     if ! livepatch_is_enabled; then
         if check_snapd_kernel_support; then
             echo 'Enabling Livepatch with the given token, stand by...'
@@ -54,11 +54,21 @@ livepatch_is_enabled() {
 livepatch_validate_token() {
     local token="$1"
 
+    if ! _livepatch_validate_token "$token"; then
+        error_msg "Invalid or missing Livepatch token"
+        error_msg "Please visit https://ubuntu.com/livepatch to obtain a Livepatch token."
+        return 1
+    fi
+}
+
+_livepatch_validate_token() {
+    local token="$1"
+
     # the livepatch token is an hex string 32 characters long
     echo "$token" | grep -q -E '^[0-9a-fA-F]{32}$'
 }
 
-_install_livepatch_prereqs() {
+_livepatch_install_prereqs() {
     install_package_if_missing_file "$SNAPD" snapd
     if ! snap list canonical-livepatch >/dev/null 2>&1; then
         echo 'Installing the canonical-livepatch snap.'

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -1,6 +1,6 @@
 # shellcheck disable=SC2034,SC2039
 
-LIVEPATCH_SERVICE_NAME="Canonical Livepatch"
+LIVEPATCH_SERVICE_TITLE="Canonical Livepatch"
 LIVEPATCH_SUPPORTED_SERIES="trusty xenial"
 LIVEPATCH_SUPPORTED_ARCHS="x86_64"
 

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -1,7 +1,8 @@
 # shellcheck disable=SC2039
 
-LIVEPATCH_SUPPORTED_SERIES="trusty xenial"
-LIVEPATCH_SUPPORTED_ARCHS="x86_64"
+LIVEPATCH_SERVICE_NAME="Canonical Livepatch" # shellcheck disable=SC2034
+LIVEPATCH_SUPPORTED_SERIES="trusty xenial" # shellcheck disable=SC2034
+LIVEPATCH_SUPPORTED_ARCHS="x86_64" # shellcheck disable=SC2034
 
 livepatch_enable() {
     local token="$1"
@@ -50,15 +51,11 @@ livepatch_is_enabled() {
     canonical-livepatch status >/dev/null 2>&1 || return 1
 }
 
-livepatch_check_support() {
-    check_service_support \
-        "Canonical Livepatch" "$LIVEPATCH_SUPPORTED_SERIES" \
-        "$LIVEPATCH_SUPPORTED_ARCHS"
-}
-
 livepatch_validate_token() {
+    local token="$1"
+
     # the livepatch token is an hex string 32 characters long
-    echo "$1" | grep -q -E '^[0-9a-fA-F]{32}$'
+    echo "$token" | grep -q -E '^[0-9a-fA-F]{32}$'
 }
 
 _install_livepatch_prereqs() {

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -41,12 +41,6 @@ service_is_enabled() {
 service_check_support() {
     local service="$1"
 
-    local service_upper
-    service_upper=$(uppercase "$service")
-    local title series archs
-    title=$(expand_var "${service_upper}_SERVICE_TITLE")
-    series=$(expand_var "${service_upper}_SUPPORTED_SERIES")
-    archs=$(expand_var "${service_upper}_SUPPORTED_ARCHS")
-    check_supported "$title" "$series" "$archs"
+    check_series_arch_supported "$service"
     call_if_defined "${service}_check_support"
 }

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -48,4 +48,5 @@ service_check_support() {
     series=$(expand_var "${service_upper}_SUPPORTED_SERIES")
     archs=$(expand_var "${service_upper}_SUPPORTED_ARCHS")
     check_service_support "$name" "$series" "$archs"
+    call_if_defined "${service}_check_support"
 }

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -1,0 +1,29 @@
+# shellcheck disable=SC2039
+
+check_user() {
+    if [ "$(id -u)" -ne 0 ]; then
+        error_msg "This command must be run as root (try using sudo)"
+        exit 2
+    fi
+}
+
+service_from_command() {
+    local command="$1"
+
+     echo "$command" | awk '
+         /^is-.*-enabled$/ {
+             match($0, /^is-(.*)-enabled$/, m);
+             print m[1];
+         }
+         /^(enable|disable)-/ {
+             match($0, /^(enable|disable)-(.*)/, m);
+             print m[2];
+         }
+    '
+}
+
+service_is_enabled() {
+    local service="$1"
+
+    "${service}_is_enabled"
+}

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -22,6 +22,16 @@ service_from_command() {
     '
 }
 
+service_enable() {
+    local service="$1"
+    local token="$2"
+
+    check_user
+    service_check_support "$service"
+    "${service}_validate_token" "$token" || exit 3
+    "${service}_enable" "$token"
+}
+
 service_is_enabled() {
     local service="$1"
 

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -27,3 +27,15 @@ service_is_enabled() {
 
     "${service}_is_enabled"
 }
+
+service_check_support() {
+    local service="$1"
+
+    local service_upper
+    service_upper=$(uppercase "$service")
+    local name series archs
+    name=$(expand_var "${service_upper}_SERVICE_NAME")
+    series=$(expand_var "${service_upper}_SUPPORTED_SERIES")
+    archs=$(expand_var "${service_upper}_SUPPORTED_ARCHS")
+    check_service_support "$name" "$series" "$archs"
+}

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -43,10 +43,10 @@ service_check_support() {
 
     local service_upper
     service_upper=$(uppercase "$service")
-    local name series archs
-    name=$(expand_var "${service_upper}_SERVICE_NAME")
+    local title series archs
+    title=$(expand_var "${service_upper}_SERVICE_TITLE")
     series=$(expand_var "${service_upper}_SUPPORTED_SERIES")
     archs=$(expand_var "${service_upper}_SUPPORTED_ARCHS")
-    check_service_support "$name" "$series" "$archs"
+    check_supported "$title" "$series" "$archs"
     call_if_defined "${service}_check_support"
 }

--- a/modules/support.sh
+++ b/modules/support.sh
@@ -7,10 +7,15 @@ not_supported() {
     exit 1
 }
 
-check_supported() {
-    local title="$1"
-    local supported_series="$2"
-    local supported_archs="$3"
+check_series_arch_supported() {
+    local service="$1"
+
+    local service_upper
+    service_upper=$(uppercase "$service")
+    local title supported_series supported_archs
+    title=$(expand_var "${service_upper}_SERVICE_TITLE")
+    supported_series=$(expand_var "${service_upper}_SUPPORTED_SERIES")
+    supported_archs=$(expand_var "${service_upper}_SUPPORTED_ARCHS")
 
     if ! is_supported_arch "$supported_archs"; then
         error_msg "Sorry, but $title is not supported on $ARCH"

--- a/modules/support.sh
+++ b/modules/support.sh
@@ -7,7 +7,7 @@ not_supported() {
     exit 1
 }
 
-check_service_support() {
+check_supported() {
     local title="$1"
     local supported_series="$2"
     local supported_archs="$3"

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -19,13 +19,6 @@ check_result() {
     fi
 }
 
-check_user() {
-    if [ "$(id -u)" -ne 0 ]; then
-        error_msg "This command must be run as root (try using sudo)"
-        exit 2
-    fi
-}
-
 name_in_list() {
     local name="$1"
     local list="$2"
@@ -37,4 +30,14 @@ name_in_list() {
         fi
     done
     return 1
+}
+
+expand_var() {
+    local var="$1"
+
+    echo "${!var}"
+}
+
+uppercase() {
+    echo "$@" | tr '[:lower:]' '[:upper:]'
 }

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -19,6 +19,13 @@ check_result() {
     fi
 }
 
+call_if_defined() {
+    local command="$1"
+
+    type -t "$command" >/dev/null || return 0
+    "$@"
+}
+
 name_in_list() {
     local name="$1"
     local list="$2"

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -23,6 +23,20 @@ class UbuntuAdvantageScriptTest(UbuntuAdvantageTest):
         self.assertEqual(1, process.returncode)
         self.assertIn('usage: ubuntu-advantage', process.stderr)
 
+    def test_invalid_command(self):
+        """Calling the script with an unknown command prints an error."""
+        process = self.script('invalid')
+        self.assertEqual(1, process.returncode)
+        self.assertIn('Invalid command: "invalid"', process.stderr)
+        self.assertIn('usage: ubuntu-advantage', process.stderr)
+
+    def test_unknown_service_command(self):
+        """Calling the script with an unknown service arg prints an error."""
+        process = self.script('break-esm')
+        self.assertEqual(1, process.returncode)
+        self.assertIn('Invalid command: "break-esm"', process.stderr)
+        self.assertIn('usage: ubuntu-advantage', process.stderr)
+
     def test_status_precise(self):
         """The status command shows livepatch not available on precise."""
         self.SERIES = 'precise'

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -106,6 +106,7 @@ main() {
     service=$(service_from_command "$command")
     # if the command contains a service name, check that it's valid
     if [ "$service" ] && ! name_in_list "$service" "$SERVICES"; then
+        error_msg "Invalid command: \"$command\""
         usage
     fi
 
@@ -114,7 +115,7 @@ main() {
         disable-livepatch)
             check_user
             service_check_support livepatch
-            remove_snap="no"
+            local remove_snap="no"
             if [ -n "$2" ]; then
                 if [ "$2" = "-r" ]; then
                     remove_snap="yes"
@@ -159,6 +160,7 @@ main() {
             ;;
 
         *)
+            error_msg "Invalid command: \"$command\""
             usage
             ;;
     esac

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -104,27 +104,12 @@ main() {
 
     local service
     service=$(service_from_command "$command")
-
+    # if the command contains a service name, check that it's valid
     if [ "$service" ] && ! name_in_list "$service" "$SERVICES"; then
         usage
     fi
 
     case "$command" in
-        is-*-enabled)
-            service_is_enabled "$service"
-            ;;
-
-        enable-livepatch)
-            check_user
-            service_check_support livepatch
-            token="$2"
-            if ! livepatch_validate_token "$token"; then
-                error_msg "Invalid or missing Livepatch token"
-                error_msg "Please visit https://ubuntu.com/livepatch to obtain a Livepatch token."
-                exit 3
-            fi
-            livepatch_enable "$token"
-            ;;
 
         disable-livepatch)
             check_user
@@ -141,33 +126,10 @@ main() {
             livepatch_disable "$remove_snap"
             ;;
 
-        enable-esm)
-            check_user
-            service_check_support esm
-            token="$2"
-            if ! validate_user_pass_token "$token"; then
-                error_msg 'Invalid token, it must be in the form "user:password"'
-                exit 3
-            fi
-            esm_enable "$token"
-            ;;
-
         disable-esm)
             check_user
             service_check_support esm
             esm_disable
-            ;;
-
-        enable-fips)
-            check_user
-            service_check_support fips
-            token="$2"
-            if ! validate_user_pass_token "$token"; then
-                error_msg 'Invalid token, it must be in the form "user:password"'
-                exit 3
-            fi
-
-            fips_enable "$token"
             ;;
 
         disable-fips)
@@ -185,6 +147,15 @@ main() {
 
         version)
             package_version ubuntu-advantage-tools
+            ;;
+
+        enable-*)
+            local token="$2"
+            service_enable "$service" "$token"
+            ;;
+
+        is-*-enabled)
+            service_is_enabled "$service"
             ;;
 
         *)

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -116,7 +116,7 @@ main() {
 
         enable-livepatch)
             check_user
-            livepatch_check_support
+            service_check_support livepatch
             token="$2"
             if ! livepatch_validate_token "$token"; then
                 error_msg "Invalid or missing Livepatch token"
@@ -128,7 +128,7 @@ main() {
 
         disable-livepatch)
             check_user
-            livepatch_check_support
+            service_check_support livepatch
             remove_snap="no"
             if [ -n "$2" ]; then
                 if [ "$2" = "-r" ]; then
@@ -143,7 +143,7 @@ main() {
 
         enable-esm)
             check_user
-            esm_check_support
+            service_check_support esm
             token="$2"
             if ! validate_user_pass_token "$token"; then
                 error_msg 'Invalid token, it must be in the form "user:password"'
@@ -154,13 +154,13 @@ main() {
 
         disable-esm)
             check_user
-            esm_check_support
+            service_check_support esm
             esm_disable
             ;;
 
         enable-fips)
             check_user
-            fips_check_support
+            service_check_support fips
             token="$2"
             if ! validate_user_pass_token "$token"; then
                 error_msg 'Invalid token, it must be in the form "user:password"'

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -3,6 +3,9 @@
 
 SCRIPTNAME=$(basename "$0")
 
+# Services managed by the script
+SERVICES="esm fips livepatch"
+
 # system details
 SERIES=${SERIES:-$(lsb_release -cs)}
 KERNEL_VERSION=${KERNEL_VERSION:-$(uname -r)}
@@ -33,8 +36,6 @@ load_modules() {
         . "$module"
     done
 }
-
-load_modules
 
 print_status() {
     local esm_status
@@ -70,7 +71,6 @@ print_status() {
     echo "fips: $fips_status"
 }
 
-
 usage() {
     cat >&2 <<EOF
 usage: ${SCRIPTNAME} <command> [parameters]
@@ -94,102 +94,105 @@ Commands:
  enable-fips <token>       enable the FIPS PPA repository and install,
                            configure and enable FIPS certified modules
  disabe-fips               currently not supported
+
 EOF
+    exit 1
+}
+
+main() {
+    local command="$1"
+
+    local service
+    service=$(service_from_command "$command")
+
+    if [ "$service" ] && ! name_in_list "$service" "$SERVICES"; then
+        usage
+    fi
+
+    case "$command" in
+        is-*-enabled)
+            service_is_enabled "$service"
+            ;;
+
+        enable-livepatch)
+            check_user
+            livepatch_check_support
+            token="$2"
+            if ! livepatch_validate_token "$token"; then
+                error_msg "Invalid or missing Livepatch token"
+                error_msg "Please visit https://ubuntu.com/livepatch to obtain a Livepatch token."
+                exit 3
+            fi
+            livepatch_enable "$token"
+            ;;
+
+        disable-livepatch)
+            check_user
+            livepatch_check_support
+            remove_snap="no"
+            if [ -n "$2" ]; then
+                if [ "$2" = "-r" ]; then
+                    remove_snap="yes"
+                else
+                    error_msg "Unknown option \"$2\""
+                    usage
+                fi
+            fi
+            livepatch_disable "$remove_snap"
+            ;;
+
+        enable-esm)
+            check_user
+            esm_check_support
+            token="$2"
+            if ! validate_user_pass_token "$token"; then
+                error_msg 'Invalid token, it must be in the form "user:password"'
+                exit 3
+            fi
+            esm_enable "$token"
+            ;;
+
+        disable-esm)
+            check_user
+            esm_check_support
+            esm_disable
+            ;;
+
+        enable-fips)
+            check_user
+            fips_check_support
+            token="$2"
+            if ! validate_user_pass_token "$token"; then
+                error_msg 'Invalid token, it must be in the form "user:password"'
+                exit 3
+            fi
+
+            fips_enable "$token"
+            ;;
+
+        disable-fips)
+            if fips_is_enabled; then
+                not_supported 'Disabling FIPS'
+            else
+                error_msg 'FIPS is not enabled.'
+                exit 1
+            fi
+            ;;
+
+        status)
+            print_status
+            ;;
+
+        version)
+            package_version ubuntu-advantage-tools
+            ;;
+
+        *)
+            usage
+            ;;
+    esac
 }
 
 
-case "$1" in
-    enable-livepatch)
-        check_user
-        livepatch_check_support
-        token="$2"
-        if ! livepatch_validate_token "$token"; then
-            error_msg "Invalid or missing Livepatch token"
-            error_msg "Please visit https://ubuntu.com/livepatch to obtain a Livepatch token."
-            exit 3
-        fi
-        livepatch_enable "$token"
-        ;;
-
-    disable-livepatch)
-        check_user
-        livepatch_check_support
-        remove_snap="no"
-        if [ -n "$2" ]; then
-            if [ "$2" = "-r" ]; then
-                remove_snap="yes"
-            else
-                error_msg "Unknown option \"$2\""
-                usage
-                exit 1
-            fi
-        fi
-        livepatch_disable "$remove_snap"
-        ;;
-
-    is-livepatch-enabled)
-        # no root needed
-        livepatch_is_enabled
-        ;;
-
-    enable-esm)
-        check_user
-        esm_check_support
-        token="$2"
-        if ! validate_user_pass_token "$token"; then
-            error_msg 'Invalid token, it must be in the form "user:password"'
-            exit 3
-        fi
-        esm_enable "$token"
-        ;;
-
-    disable-esm)
-        check_user
-        esm_check_support
-        esm_disable
-        ;;
-
-    is-esm-enabled)
-        # no root needed
-        esm_is_enabled
-        ;;
-
-    enable-fips)
-        check_user
-        fips_check_support
-        token="$2"
-        if ! validate_user_pass_token "$token"; then
-            error_msg 'Invalid token, it must be in the form "user:password"'
-            exit 3
-        fi
-
-        fips_enable "$token"
-        ;;
-
-    disable-fips)
-        if fips_is_enabled; then
-            not_supported 'Disabling FIPS'
-        else
-            error_msg 'FIPS is not enabled.'
-            exit 1
-        fi
-        ;;
-
-    is-fips-enabled)
-        # no root needed
-        fips_is_enabled
-        ;;
-
-    status)
-        print_status
-        ;;
-
-    version)
-        package_version ubuntu-advantage-tools
-        ;;
-
-    *)
-        usage
-        exit 1
-        ;;
-esac
+load_modules
+main "$@"


### PR DESCRIPTION
Unify the logic for `enable-<service>` and `is-<service>-enabled` commands, reducing duplication.
A followup branch will take care of `disable-<service>` as well