### PR TITLE
Use sed instead of awk

### DIFF
--- a/modules/service.sh
+++ b/modules/service.sh
@@ -12,7 +12,7 @@ service_from_command() {
 
      echo "$command" | sed -n -r \
          "s,^is-([^-]+)-enabled$,\1,p;\
-          s,^(enable|disabled)-([^-]+)$,\2,p"
+          s,^(enable|disable)-([^-]+)$,\2,p"
 }
 
 service_enable() {

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -11,8 +11,8 @@ service_from_command() {
     local command="$1"
 
      echo "$command" | sed -n -r \
-         "s,^is-([^-]+)-enabled$,\1,p;\
-          s,^(enable|disable)-([^-]+)$,\2,p"
+         "s,^is-(.+)-enabled$,\1,p;\
+          s,^(enable|disable)-(.+)$,\2,p"
 }
 
 service_enable() {

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -10,16 +10,9 @@ check_user() {
 service_from_command() {
     local command="$1"
 
-     echo "$command" | awk '
-         /^is-.*-enabled$/ {
-             match($0, /^is-(.*)-enabled$/, m);
-             print m[1];
-         }
-         /^(enable|disable)-/ {
-             match($0, /^(enable|disable)-(.*)/, m);
-             print m[2];
-         }
-    '
+     echo "$command" | sed -n -r \
+         "s,^is-([^-]+)-enabled$,\1,p;\
+          s,^(enable|disabled)-([^-]+)$,\2,p"
 }
 
 service_enable() {

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -11,8 +11,8 @@ service_from_command() {
     local command="$1"
 
      echo "$command" | sed -n -r \
-         's,^is-(.+)-enabled$,\1,p;'\
-          's,^(enable|disable)-(.+)$,\2,p'
+         's,^is-(.+)-enabled$,\1,p;
+          s,^(enable|disable)-(.+)$,\2,p'
 }
 
 service_enable() {

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -11,8 +11,8 @@ service_from_command() {
     local command="$1"
 
      echo "$command" | sed -n -r \
-         "s,^is-(.+)-enabled$,\1,p;\
-          s,^(enable|disable)-(.+)$,\2,p"
+         's,^is-(.+)-enabled$,\1,p;'\
+          's,^(enable|disable)-(.+)$,\2,p'
 }
 
 service_enable() {


### PR DESCRIPTION
Use sed instead of awk because the minimal awk we get installed by default does not support the expression we were using. Fixes #107.