### PR TITLE
Cleanups to repository URLs

### DIFF
--- a/modules/apt.sh
+++ b/modules/apt.sh
@@ -5,8 +5,8 @@ private_repo_url() {
     local credentials="$2"
     local file="$3"
 
-    local repo_schema="${repo_url/:\/\/*/}}"
-    echo "${repo_schema}://${credentials}@${repo_url/*:\/\//}/ubuntu${file}"
+    local repo_scheme="${repo_url/:\/\/*/}}"
+    echo "${repo_scheme}://${credentials}@${repo_url/*:\/\//}/ubuntu${file}"
 }
 
 package_version() {
@@ -75,14 +75,15 @@ _apt_add_auth() {
     local password="${credentials#*:}"
     [ -f "$APT_AUTH_FILE" ] || touch "$APT_AUTH_FILE"
     chmod 600 "$APT_AUTH_FILE"
-    echo "machine ${repo_url/*:\/\//}/ubuntu/ login ${login} password ${password}" \
+    local repo_host_path="${repo_url/*:\/\//}"
+    echo "machine ${repo_host_path}/ubuntu/ login ${login} password ${password}" \
          >>"$APT_AUTH_FILE"
 }
 
 _apt_remove_auth() {
     local repo_url="$1"
 
-    local repo_host_path=${repo_url/*:\/\//}
+    local repo_host_path="${repo_url/*:\/\//}"
     local tempfile
     tempfile=$(mktemp)
     chmod 600 "$tempfile"

--- a/modules/apt.sh
+++ b/modules/apt.sh
@@ -81,6 +81,12 @@ _apt_add_auth() {
 _apt_remove_auth() {
     local repo_path="$1"
 
-    # shellcheck disable=SC1117
-    sed -i "/^machine ${repo_path}\/ubuntu\/ login/d" "$APT_AUTH_FILE"
+    local tempfile
+    tempfile=$(mktemp)
+    chmod 600 "$tempfile"
+    # don't use pattern matching as the repo path contains slashes and dots
+    awk -v repo_path="${repo_path}/ubuntu/" \
+        '! ($1 == "machine" && $2 == repo_path)' \
+        "$APT_AUTH_FILE"  >"$tempfile"
+    mv "$tempfile" "$APT_AUTH_FILE"
 }

--- a/modules/service-esm.sh
+++ b/modules/service-esm.sh
@@ -4,7 +4,7 @@ ESM_SERVICE_TITLE="Extended Security Maintenance"
 ESM_SUPPORTED_SERIES="precise"
 ESM_SUPPORTED_ARCHS="ALL"
 
-ESM_REPO_URL="esm.ubuntu.com"
+ESM_REPO_URL="https://esm.ubuntu.com"
 ESM_REPO_KEY_FILE="ubuntu-esm-keyring.gpg"
 ESM_REPO_LIST=${ESM_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 

--- a/modules/service-fips.sh
+++ b/modules/service-fips.sh
@@ -4,7 +4,7 @@ FIPS_SERVICE_TITLE="Canonical FIPS 140-2 Modules"
 FIPS_SUPPORTED_SERIES="xenial"
 FIPS_SUPPORTED_ARCHS="x86_64 ppc64le s390x"
 
-FIPS_REPO_URL="private-ppa.launchpad.net/ubuntu-advantage/fips"
+FIPS_REPO_URL="https://private-ppa.launchpad.net/ubuntu-advantage/fips"
 FIPS_REPO_KEY_FILE="ubuntu-fips-keyring.gpg"
 FIPS_REPO_LIST=${FIPS_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-fips-${SERIES}.list"}
 FIPS_ENABLED_FILE=${FIPS_ENABLED_FILE:-"/proc/sys/crypto/fips_enabled"}

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -80,8 +80,9 @@ ESM_DISABLED = """
 echo "500 http://archive.ubuntu.com/ubuntu precise/main amd64 Packages"
 """
 
+
 ESM_ENABLED = """
-echo "500 http://esm.ubuntu.com/ubuntu precise/main amd64 Packages"
+echo "500 https://esm.ubuntu.com/ubuntu precise/main amd64 Packages"
 """
 
 APT_GET_LOG_WRAPPER = """

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -223,12 +223,11 @@ class ESMTest(UbuntuAdvantageTest):
 
     def test_is_esm_enabled_true(self):
         """is-esm-enabled returns 0 if the repository is enabled."""
-        self.make_fake_binary('apt-cache', command='echo esm.ubuntu.com')
+        self.setup_esm(enabled=True)
         process = self.script('is-esm-enabled')
         self.assertEqual(0, process.returncode)
 
     def test_is_esm_enabled_false(self):
         """is-esm-enabled returns 1 if the repository is not enabled."""
-        self.make_fake_binary('apt-cache')
         process = self.script('is-esm-enabled')
         self.assertEqual(1, process.returncode)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -48,7 +48,7 @@ class UbuntuAdvantageScriptTest(UbuntuAdvantageTest):
     def test_status_precise_esm_enabled(self):
         """The status command shows esm enabled."""
         self.SERIES = 'precise'
-        self.make_fake_binary('apt-cache', command='echo esm.ubuntu.com')
+        self.setup_esm(enabled=True)
         self.setup_livepatch(installed=False, enabled=False)
         process = self.script('status')
         self.assertIn("livepatch: disabled (not available)", process.stdout)


### PR DESCRIPTION
Include schema in repository URLs. This also makes the match a bit safer when removing repository credentials from the auth file.

Fixes #100 

Note: depends on #117 