### PR TITLE
check that all prerequisite packages are installed when enabling FIPS

### DIFF
--- a/modules/apt.sh
+++ b/modules/apt.sh
@@ -52,14 +52,14 @@ apt_get() {
                    apt-get -y -o Dpkg::Options::='--force-confold' "$@"
 }
 
-is_package_installed() {
+apt_is_package_installed() {
     local package="$1"
 
     dpkg-query -s "$package" >/dev/null 2>&1
 }
 
 # Install a package if the specified file doesn't exist
-install_package_if_missing_file() {
+apt_install_package_if_missing_file() {
     local file="$1"
     local package="$2"
 

--- a/modules/service-esm.sh
+++ b/modules/service-esm.sh
@@ -14,8 +14,8 @@ esm_enable() {
     check_token "$ESM_REPO_URL" "$token"
     apt_add_repo "$ESM_REPO_LIST" "$ESM_REPO_URL" "$token" \
                  "${KEYRINGS_DIR}/${ESM_REPO_KEY_FILE}"
-    install_package_if_missing_file "$APT_METHOD_HTTPS" apt-transport-https
-    install_package_if_missing_file "$CA_CERTIFICATES" ca-certificates
+    apt_install_package_if_missing_file "$APT_METHOD_HTTPS" apt-transport-https
+    apt_install_package_if_missing_file "$CA_CERTIFICATES" ca-certificates
     echo -n 'Running apt-get update... '
     check_result apt_get update
     echo 'Ubuntu ESM repository enabled.'

--- a/modules/service-fips.sh
+++ b/modules/service-fips.sh
@@ -30,8 +30,8 @@ fips_enable() {
                  "${KEYRINGS_DIR}/${FIPS_REPO_KEY_FILE}"
     apt_add_repo_pinning "$FIPS_REPO_PREFERENCES" \
                          LP-PPA-ubuntu-advantage-fips 1001
-    install_package_if_missing_file "$APT_METHOD_HTTPS" apt-transport-https
-    install_package_if_missing_file "$CA_CERTIFICATES" ca-certificates
+    apt_install_package_if_missing_file "$APT_METHOD_HTTPS" apt-transport-https
+    apt_install_package_if_missing_file "$CA_CERTIFICATES" ca-certificates
     echo -n 'Running apt-get update... '
     check_result apt_get update
     echo 'Ubuntu FIPS PPA repository enabled.'
@@ -51,7 +51,7 @@ fips_disable() {
 }
 
 fips_is_enabled() {
-    is_package_installed fips-initramfs && [ "$(_fips_enabled_check)" -eq 1 ]
+    apt_is_package_installed fips-initramfs && [ "$(_fips_enabled_check)" -eq 1 ]
 }
 
 fips_validate_token() {
@@ -137,6 +137,6 @@ _fips_check_installed() {
 _fips_check_packages_installed() {
     local pkg
     for pkg in $FIPS_HMAC_PACKAGES; do
-        is_package_installed "$pkg" || return 1
+        apt_is_package_installed "$pkg" || return 1
     done
 }

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -81,7 +81,7 @@ _livepatch_validate_token() {
 }
 
 _livepatch_install_prereqs() {
-    install_package_if_missing_file "$SNAPD" snapd
+    apt_install_package_if_missing_file "$SNAPD" snapd
     if ! snap list canonical-livepatch >/dev/null 2>&1; then
         echo 'Installing the canonical-livepatch snap.'
         echo 'This may take a few minutes depending on your bandwidth.'

--- a/tests/test_fips.py
+++ b/tests/test_fips.py
@@ -72,6 +72,15 @@ class FIPSTest(UbuntuAdvantageTest):
             'Please reboot into the FIPS kernel to enable it.',
             process.stderr.strip())
 
+    def test_enable_fips_not_all_packages_installed(self):
+        # one of the packages is not installed
+        self.make_fake_binary(
+            'dpkg-query', command='[ $2 != openssh-client-hmac ]')
+        process = self.script('enable-fips', 'user:pass')
+        self.assertEqual(process.returncode, 0)
+        self.assertIn('Installing FIPS packages', process.stdout)
+        self.assertIn('Successfully configured FIPS', process.stdout)
+
     def test_enable_fips_writes_config(self):
         """The enable-fips option writes fips configuration."""
         self.script('enable-fips', 'user:pass')


### PR DESCRIPTION
Fixes #102 

Also, prefix all package-related functions with `apt_` (for namespacing)