### PR TITLE
Implement a cache for the livepatch motd (fixes #122)

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -1,0 +1,1 @@
+var/cache/ubuntu-advantage-tools

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+STAMP_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp
+
+if [ "$1" = purge -a -f $STAMP_FILE ]; then
+    rm $STAMP_FILE
+fi
+
+#DEBHELPER#
+

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -e
 
 STAMP_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-CACHE_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp
+CACHE_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.cache
 
 if [ "$1" = purge -a -f "$CACHE_FILE" ]; then
     rm "$CACHE_FILE"

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,9 +1,9 @@
 #!/bin/sh -e
 
-STAMP_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp
+CACHE_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp
 
-if [ "$1" = purge -a -f "$STAMP_FILE" ]; then
-    rm "$STAMP_FILE"
+if [ "$1" = purge -a -f "$CACHE_FILE" ]; then
+    rm "$CACHE_FILE"
 fi
 
 #DEBHELPER#

--- a/debian/postrm
+++ b/debian/postrm
@@ -4,8 +4,8 @@ set -e
 
 STAMP_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp
 
-if [ "$1" = purge -a -f $STAMP_FILE ]; then
-    rm $STAMP_FILE
+if [ "$1" = purge -a -f "$STAMP_FILE" ]; then
+    rm "$STAMP_FILE"
 fi
 
 #DEBHELPER#

--- a/debian/ubuntu-advantage-tools.cron.hourly
+++ b/debian/ubuntu-advantage-tools.cron.hourly
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+UA="/usr/bin/ubuntu-advantage"
+STAMP_DIR="/var/cache/ubuntu-advantage-tools"
+STAMP_FILE="$STAMP_DIR/ubuntu-advantage-status.stamp"
+
+[ -x "$UA" ] || exit 0
+
+[ -d "$STAMP_DIR" ] || mkdir -p "$STAMP_DIR"
+
+"$UA" status > "$STAMP_FILE"
+

--- a/debian/ubuntu-advantage-tools.cron.hourly
+++ b/debian/ubuntu-advantage-tools.cron.hourly
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -e
 
 UA="/usr/bin/ubuntu-advantage"
 STAMP_DIR="/var/cache/ubuntu-advantage-tools"

--- a/debian/ubuntu-advantage-tools.cron.hourly
+++ b/debian/ubuntu-advantage-tools.cron.hourly
@@ -2,7 +2,7 @@
 
 UA="/usr/bin/ubuntu-advantage"
 CACHE_DIR="/var/cache/ubuntu-advantage-tools"
-CACHE_FILE="$CACHE_DIR/ubuntu-advantage-status.stamp"
+CACHE_FILE="$CACHE_DIR/ubuntu-advantage-status.cache"
 
 [ -x "$UA" ] || exit 0
 

--- a/debian/ubuntu-advantage-tools.cron.hourly
+++ b/debian/ubuntu-advantage-tools.cron.hourly
@@ -1,12 +1,12 @@
 #!/bin/sh -e
 
 UA="/usr/bin/ubuntu-advantage"
-STAMP_DIR="/var/cache/ubuntu-advantage-tools"
-STAMP_FILE="$STAMP_DIR/ubuntu-advantage-status.stamp"
+CACHE_DIR="/var/cache/ubuntu-advantage-tools"
+CACHE_FILE="$CACHE_DIR/ubuntu-advantage-status.stamp"
 
 [ -x "$UA" ] || exit 0
 
-[ -d "$STAMP_DIR" ] || mkdir -p "$STAMP_DIR"
+[ -d "$CACHE_DIR" ] || mkdir -p "$CACHE_DIR"
 
-"$UA" status > "$STAMP_FILE"
+"$UA" status > "$CACHE_FILE"
 

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -64,6 +64,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.ca_certificates = self.bin_dir / 'update-ca-certificates'
         self.snapd = self.bin_dir / 'snapd'
         self.apt_helper = self.bin_dir / 'apt-helper'
+        self.ua_status_cache = Path(self.tempdir.join('ua-status-cache'))
         # setup directories and files
         self.bin_dir.mkdir()
         self.keyrings_dir.mkdir()
@@ -100,6 +101,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         path = os.pathsep.join([str(self.bin_dir), os.environ['PATH']])
         env = {
             'UA': './ubuntu-advantage',
+            'UA_STATUS_CACHE': str(self.ua_status_cache),
             'PATH': path,
             'FSTAB': str(self.fstab),
             'CPUINFO': str(self.cpuinfo),

--- a/update-motd.d/99-livepatch
+++ b/update-motd.d/99-livepatch
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 UA=${UA:-"/usr/bin/ubuntu-advantage"}
-UA_STATUS_CACHE=${UA_STATUS_CACHE:-"/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp"}
+UA_STATUS_CACHE=${UA_STATUS_CACHE:-"/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.cache"}
 
 [ -x "$UA" ] || exit 0
 

--- a/update-motd.d/99-livepatch
+++ b/update-motd.d/99-livepatch
@@ -62,7 +62,7 @@ fi
 service_name="livepatch"
 # if there is no cache file yet (the cron job hasn't run yet), create a
 # fresh one. We also want to ignore an empty cache file.
-[ -s "$UA_STATUS_CACHE" ] || "$UA" status > "$UA_STATUS_CACHE" 2>&1
+[ -s "$UA_STATUS_CACHE" ] || "$UA" status > "$UA_STATUS_CACHE" 2>/dev/null
 ua_status=$(cat "$UA_STATUS_CACHE")
 # if there is no livepatch section at all in the output, silently
 # bail

--- a/update-motd.d/99-livepatch
+++ b/update-motd.d/99-livepatch
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 UA=${UA:-"/usr/bin/ubuntu-advantage"}
+UA_STATUS_CACHE=${UA_STATUS_CACHE:-"/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.stamp"}
 
 [ -x "$UA" ] || exit 0
 
@@ -59,7 +60,10 @@ if ! echo "$PATH" | grep -qE "(^|:)/snap/bin/?(:|$)"; then
 fi
 
 service_name="livepatch"
-ua_status=$($UA status 2>&1)
+# if there is no cache file yet (the cron job hasn't run yet), create a
+# fresh one. We also want to ignore an empty cache file.
+[ -s "$UA_STATUS_CACHE" ] || "$UA" status > "$UA_STATUS_CACHE" 2>&1
+ua_status=$(cat "$UA_STATUS_CACHE")
 # if there is no livepatch section at all in the output, silently
 # bail
 has_livepatch=$(echo "${ua_status}" | grep "^${service_name}")


### PR DESCRIPTION
Ideas for follow-up branches:

 - update the cache every time the user calls "ua status"
 - update the cache right after an enable or disable call

PPA with (manual) test builds: https://launchpad.net/~ahasenack/+archive/ubuntu/ua-livepatch-motd-cache/+packages