### PR TITLE
Add the snap bin directory to PATH in the main ubuntu-advantage script

### DIFF
--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -113,5 +113,9 @@ main() {
 }
 
 
+if ! echo "$PATH" | grep -qE "(^|:)/snap/bin/?(:|$)"; then
+    PATH="/snap/bin:$PATH"
+fi
+
 load_modules
 main "$@"

--- a/update-motd.d/99-livepatch
+++ b/update-motd.d/99-livepatch
@@ -55,10 +55,6 @@ print_status() {
 }
 
 
-if ! echo "$PATH" | grep -qE "(^|:)/snap/bin/?(:|$)"; then
-    PATH="/snap/bin:$PATH"
-fi
-
 service_name="livepatch"
 # if there is no cache file yet (the cron job hasn't run yet), create a
 # fresh one. We also want to ignore an empty cache file.


### PR DESCRIPTION
instead of in the other scripts that might call ua. (Fixes #126)