### PR TITLE
Livepatch unsupported kernel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-advantage-tools (18) UNRELEASED; urgency=medium
+
+  * Have ua status cope with the additional livepatch of running a kernel
+    that is not supported for livepatches.
+
+ -- Andreas Hasenack <andreas@canonical.com>  Thu, 24 May 2018 17:26:25 -0300
+
 ubuntu-advantage-tools (17) bionic; urgency=medium
 
   * New upstream release

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -59,6 +59,17 @@ livepatch_is_enabled() {
     canonical-livepatch status >/dev/null 2>&1 || return 1
 }
 
+livepatch_disabled_reason() {
+    local output
+    local result=0
+    local unsupported_kernel_msg="is not eligible for livepatch updates"
+
+    output=$(canonical-livepatch status 2>&1) || result=$?
+    if echo "${output}" | grep -q "${unsupported_kernel_msg}"; then
+        echo " (unsupported kernel)"
+    fi
+}
+
 livepatch_print_status() {
     canonical-livepatch status
 }

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -49,6 +49,8 @@ service_print_status() {
         status="disabled"
         if ! is_supported "$series" "$archs"; then
             status+=" (not available)"
+        else
+            status+=$(service_disabled_reason "${service}")
         fi
     fi
 
@@ -56,6 +58,12 @@ service_print_status() {
     if [ "$status" = enabled ]; then
         _service_print_detailed_status "$service"
     fi
+}
+
+service_disabled_reason() {
+    local service="$1"
+
+    call_if_defined "${service}_disabled_reason"
 }
 
 service_check_user() {

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -169,6 +169,12 @@ fips: disabled (not available)
 livepatch: disabled (not available)
 """
 
+STATUS_CACHE_LIVEPATCH_DISABLED_UNSUPPORTED = """\
+esm: disabled (not available)
+fips: disabled (not available)
+livepatch: disabled (unsupported kernel)
+"""
+
 STATUS_CACHE_MIXED_CONTENT = """\
 esm: enabled
     patchState: should-not-be-here

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -30,6 +30,16 @@ EOF
 fi
 """
 
+# regardless of the command, canonical-livepatch will always exit with
+# status 1 and a message like this
+LIVEPATCH_UNSUPPORTED_KERNEL = """
+cat <<EOF
+2018/05/24 18:51:29 cannot use livepatch: your kernel "4.15.0-1010-kvm" \
+is not eligible for livepatch updates
+EOF
+exit 1
+"""
+
 LIVEPATCH_ENABLED = """
 if [ "$1" = "status" ]; then
     cat <<EOF

--- a/tests/test_livepatch_motd.py
+++ b/tests/test_livepatch_motd.py
@@ -9,6 +9,7 @@ from fakes import (
     STATUS_CACHE_LIVEPATCH_ENABLED_NO_CONTENT,
     STATUS_CACHE_LIVEPATCH_DISABLED_AVAILABLE,
     STATUS_CACHE_LIVEPATCH_DISABLED_UNAVAILABLE,
+    STATUS_CACHE_LIVEPATCH_DISABLED_UNSUPPORTED,
     STATUS_CACHE_MIXED_CONTENT)
 from random import randrange
 
@@ -97,6 +98,19 @@ class LivepatchMOTDTest(UbuntuAdvantageTest):
         process = self.script()
         self.assertEqual(0, process.returncode)
         self.assertEqual('', process.stdout)
+
+    def test_disabled_unsupported(self):
+        """Livepatch is disabled and unsupported."""
+        self.KERNEL_VERSION = '4.15.0-1010-kvm'
+        self.ua_status_cache.write_text(
+            STATUS_CACHE_LIVEPATCH_DISABLED_UNSUPPORTED)
+        process = self.script()
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Canonical Livepatch is installed but disabled',
+                      process.stdout)
+        self.assertIn('Your running kernel {} is not supported.'.format(
+                      self.KERNEL_VERSION),
+                      process.stdout)
 
     def test_other_state_fields_ignored(self):
         """The MOTD script ignores *State fields not from livepatch."""

--- a/tests/test_livepatch_motd.py
+++ b/tests/test_livepatch_motd.py
@@ -108,8 +108,8 @@ class LivepatchMOTDTest(UbuntuAdvantageTest):
         self.assertEqual(0, process.returncode)
         self.assertIn('Canonical Livepatch is installed but disabled',
                       process.stdout)
-        self.assertIn('Your running kernel {} is not supported.'.format(
-                      self.KERNEL_VERSION),
+        self.assertIn('Kernel {} is not supported (https://bit.ly/'
+                      'livepatch-faq)'.format(self.KERNEL_VERSION),
                       process.stdout)
 
     def test_other_state_fields_ignored(self):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,6 +1,7 @@
 """Tests for the ubuntu-advantage script."""
 
 from testing import UbuntuAdvantageTest
+from fakes import LIVEPATCH_UNSUPPORTED_KERNEL
 
 
 class UbuntuAdvantageScriptTest(UbuntuAdvantageTest):
@@ -90,6 +91,16 @@ class UbuntuAdvantageScriptTest(UbuntuAdvantageTest):
         """The script exits with error on unknown service status name."""
         process = self.script('status', 'unknown')
         self.assertEqual(process.returncode, 1)
+
+    def test_status_livepatch_unsupported_kernel(self):
+        """Livepatch is unavailable on an unsupported kernel."""
+        self.SERIES = 'xenial'
+        self.setup_livepatch(
+            installed=True, enabled=False,
+            livepatch_command=LIVEPATCH_UNSUPPORTED_KERNEL)
+        process = self.script('status')
+        self.assertIn('livepatch: disabled (unsupported kernel)',
+                      process.stdout)
 
     def test_version(self):
         """The version command shows the package version."""

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -95,6 +95,7 @@ class UbuntuAdvantageScriptTest(UbuntuAdvantageTest):
     def test_status_livepatch_unsupported_kernel(self):
         """Livepatch is unavailable on an unsupported kernel."""
         self.SERIES = 'xenial'
+        self.ARCH = 'x86_64'
         self.setup_livepatch(
             installed=True, enabled=False,
             livepatch_command=LIVEPATCH_UNSUPPORTED_KERNEL)

--- a/update-motd.d/80-livepatch
+++ b/update-motd.d/80-livepatch
@@ -77,7 +77,7 @@ case "$livepatch_status" in
     "disabled (unsupported kernel)")
         echo
         echo " * Canonical Livepatch is installed but disabled"
-        echo "   - Your running kernel ${KERNEL_VERSION} is not supported."
+        echo "   - Kernel ${KERNEL_VERSION} is not supported (https://bit.ly/livepatch-faq)"
         ;;
     "enabled")
         echo

--- a/update-motd.d/80-livepatch
+++ b/update-motd.d/80-livepatch
@@ -2,6 +2,7 @@
 
 UA=${UA:-"/usr/bin/ubuntu-advantage"}
 UA_STATUS_CACHE=${UA_STATUS_CACHE:-"/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.cache"}
+KERNEL_VERSION=${KERNEL_VERSION:-"$(uname -r)"}
 
 [ -x "$UA" ] || exit 0
 
@@ -72,6 +73,11 @@ check_state=$(echo "$ua_status"|sed -r -n "/^${service_name}:/,/^\\S/s,^[[:blank
 case "$livepatch_status" in
     "disabled (not available)")
         # do nothing
+        ;;
+    "disabled (unsupported kernel)")
+        echo
+        echo " * Canonical Livepatch is installed but disabled"
+        echo "   - Your running kernel ${KERNEL_VERSION} is not supported."
         ;;
     "enabled")
         echo


### PR DESCRIPTION
Fixes #142 

This branch updates the MOTD and "ua status" outputs to cope with an unsupported kernel for livepatch.
The livepatch case is a bit odd because we can only know if the running kernel is supported or not after the canonical-livepatch snap is installed and the canonical-livepatch command is run.

Sample MOTD output:

```
andreas@nsnx:~$ ssh 192.168.122.170
Warning: Permanently added '192.168.122.170' (ECDSA) to the list of known hosts.
Welcome to Ubuntu 18.04 LTS (GNU/Linux 4.15.0-1010-kvm x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Thu May 24 21:29:27 UTC 2018

  System load:  0.02              Processes:           62
  Usage of /:   19.4% of 7.58GB   Users logged in:     0
  Memory usage: 23%               IP address for ens3: 192.168.122.170
  Swap usage:   0%


  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

 * Canonical Livepatch is installed but disabled
   - Your running kernel 4.15.0-1010-kvm is not supported.

0 packages can be updated.
0 updates are security updates.


Last login: Thu May 24 18:28:52 2018 from 192.168.122.1
ubuntu@ubuntu:~$ uname -r
4.15.0-1010-kvm
```

ua status output:
```
ubuntu@ubuntu:~$ ua status
esm: disabled (not available)
fips: disabled (not available)
livepatch: disabled (unsupported kernel)
```

@dpb1 please take a look at the sample outputs above, see if that is what you would expect.