### PR TITLE
Add new flag enable-cisaudit to support cis audit

### DIFF
--- a/modules/service-cis.sh
+++ b/modules/service-cis.sh
@@ -42,10 +42,14 @@ cisaudit_disable() {
                         "$APT_KEYS_DIR/$CISAUDIT_REPO_KEY_FILE"
         echo -n 'Running apt-get update... '
         check_result apt_get update
-        check_result apt_get remove $CISAUDIT_UBUNTU_CISBENCHMARK
-        echo "Canonical CIS Benchmark 16.04 Audit Tool Disabled."
+        echo "Canonical CIS Benchmark 16.04 Audit Tool Repository Disabled."
     else
-        echo 'Canonical CIS Benchmark 16.04 Audit Tool is not enabled.'
+        echo 'Canonical CIS Benchmark 16.04 Audit Tool Repository is not Enabled.'
+    fi
+
+    if apt_is_package_installed $CISAUDIT_UBUNTU_CISBENCHMARK; then
+        check_result apt_get remove $CISAUDIT_UBUNTU_CISBENCHMARK
+        echo 'Canonical CIS Benchmark 16.04 Audit Tool Removed.'
     fi
 }
 

--- a/modules/service-cis.sh
+++ b/modules/service-cis.sh
@@ -1,13 +1,13 @@
 # shellcheck disable=SC2034,SC2039
  
-CISAUDIT_SERVICE_TITLE="Canonical CIS 16.04 Benchmark Audit Tool"
+CISAUDIT_SERVICE_TITLE="Canonical CIS Benchmark 16.04 Audit Tool"
 CISAUDIT_SUPPORTED_SERIES="xenial"
 CISAUDIT_SUPPORTED_ARCHS="x86_64 ppc64le s390x"
 
 CISAUDIT_REPO_URL="https://private-ppa.launchpad.net/ubuntu-advantage/security-benchmarks"
 CISAUDIT_REPO_KEY_FILE="ubuntu-securitybenchmarks-keyring.gpg"
 CISAUDIT_REPO_LIST=${CISAUDIT_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-cis-${SERIES}.list"}
-CISAUDIT_UBUNTU_CISBENCHMARK="cisbenchmark-16.04"
+CISAUDIT_UBUNTU_CISBENCHMARK="ubuntu-cisbenchmark-16.04"
 
 cisaudit_enable() {
     local token="$1"
@@ -15,7 +15,7 @@ cisaudit_enable() {
 
     _cisaudit_is_installed || result=$?
     if [ $result -eq 0 ]; then
-        error_msg "CIS audit package is already installed and files are available in /usr/lib/ubuntu-securityguides/cisbenchmark-16.04."
+        error_msg "CIS benchmark audit package is already installed and files are available in /usr/share/ubuntu-securityguides/$CISAUDIT_UBUNTU_CISBENCHMARK."
         error_exit service_already_enabled
     fi
 
@@ -33,11 +33,20 @@ cisaudit_enable() {
     check_result apt_get install $CISAUDIT_UBUNTU_CISBENCHMARK
 
     echo "Successfully installed the CIS audit tool."
-    echo "Please follow instructions in /usr/share/doc/cisbenchmark-16.04/README to run the CIS audit tool on the target machine(s)."
+    echo "Please follow instructions in /usr/share/doc/$CISAUDIT_UBUNTU_CISBENCHMARK/README to run the CIS audit tool on the target machine(s)."
 }
 
 cisaudit_disable() {
-    not_supported 'Disabling CIS Audit tool install'
+    if [ -f "$CISAUDIT_REPO_LIST" ]; then
+        apt_remove_repo "$CISAUDIT_REPO_LIST" "$CISAUDIT_REPO_URL" \
+                        "$APT_KEYS_DIR/$CISAUDIT_REPO_KEY_FILE"
+        echo -n 'Running apt-get update... '
+        check_result apt_get update
+        check_result apt_get remove $CISAUDIT_UBUNTU_CISBENCHMARK
+        echo "Canonical CIS Benchmark 16.04 Audit Tool Disabled."
+    else
+        echo 'Canonical CIS Benchmark 16.04 Audit Tool is not enabled.'
+    fi
 }
 
 cisaudit_is_enabled() {
@@ -45,7 +54,7 @@ cisaudit_is_enabled() {
 }
 
 cisaudit_print_status() {
-    echo "cisaudit: files are in /usr/lib/ubuntu-securityguides/cisbenchmark-16.04"
+    echo "cisaudit: files are in /usr/share/ubuntu-securityguides/$CISAUDIT_UBUNTU_CISBENCHMARK"
 }
 
 _cisaudit_is_installed() {

--- a/modules/service-cis.sh
+++ b/modules/service-cis.sh
@@ -1,0 +1,62 @@
+# shellcheck disable=SC2034,SC2039
+ 
+CISAUDIT_SERVICE_TITLE="Canonical CIS 16.04 Benchmark Audit Tool"
+CISAUDIT_SUPPORTED_SERIES="xenial"
+CISAUDIT_SUPPORTED_ARCHS="x86_64 ppc64le s390x"
+
+CISAUDIT_REPO_URL="https://private-ppa.launchpad.net/ubuntu-advantage/security-benchmarks"
+CISAUDIT_REPO_KEY_FILE="ubuntu-securitybenchmarks-keyring.gpg"
+CISAUDIT_REPO_LIST=${CISAUDIT_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-cis-${SERIES}.list"}
+CISAUDIT_UBUNTU_CISBENCHMARK="cisbenchmark-16.04"
+
+cisaudit_enable() {
+    local token="$1"
+    local result=0
+
+    _cisaudit_is_installed || result=$?
+    if [ $result -eq 0 ]; then
+        error_msg "CIS audit package is already installed and files are available in /usr/lib/ubuntu-securityguides/cisbenchmark-16.04."
+        error_exit service_already_enabled
+    fi
+
+    check_token "$CISAUDIT_REPO_URL" "$token"
+    apt_add_repo "$CISAUDIT_REPO_LIST" "$CISAUDIT_REPO_URL" "$token" \
+                 "${KEYRINGS_DIR}/${CISAUDIT_REPO_KEY_FILE}"
+    apt_install_package_if_missing_file "$APT_METHOD_HTTPS" apt-transport-https
+    apt_install_package_if_missing_file "$CA_CERTIFICATES" ca-certificates
+    echo -n 'Running apt-get update... '
+    check_result apt_get update
+    echo 'Ubuntu Security Benchmarks PPA repository enabled.'
+
+    echo -n 'Installing CIS audit benchmark tool (this may take a while)... '
+    # shellcheck disable=SC2086
+    check_result apt_get install $CISAUDIT_UBUNTU_CISBENCHMARK
+
+    echo "Successfully installed the CIS audit tool."
+    echo "Please follow instructions in /usr/share/doc/cisbenchmark-16.04/README to run the CIS audit tool on the target machine(s)."
+}
+
+cisaudit_disable() {
+    not_supported 'Disabling CIS Audit tool install'
+}
+
+cisaudit_is_enabled() {
+    _cisaudit_is_installed
+}
+
+cisaudit_print_status() {
+    echo "cisaudit: files are in /usr/lib/ubuntu-securityguides/cisbenchmark-16.04"
+}
+
+_cisaudit_is_installed() {
+    apt_is_package_installed $CISAUDIT_UBUNTU_CISBENCHMARK && return 0 
+}
+
+cisaudit_validate_token() {
+    local token="$1"
+
+    if ! validate_user_pass_token "$token"; then
+        error_msg 'Invalid token, it must be in the form "user:password"'
+        return 1
+    fi
+}

--- a/tests/test_cisaudit.py
+++ b/tests/test_cisaudit.py
@@ -1,0 +1,164 @@
+"""Tests for CISAudit-related commands."""
+
+from testing import UbuntuAdvantageTest
+
+
+class CISAUDITTest(UbuntuAdvantageTest):
+
+    SERIES = 'xenial'
+    ARCH = 'x86_64'
+
+    def setUp(self):
+        super().setUp()
+        self.setup_cisaudit()
+
+    def test_enable_cisaudit_provisioning(self):
+        """The enable-cisaudit enables security benchmarks repository."""
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(0, process.returncode)
+        self.assertIn(
+            'Ubuntu Security Benchmarks PPA repository enabled.',
+            process.stdout)
+        expected = (
+            'deb https://private-ppa.launchpad.net/ubuntu-advantage/'
+            'security-benchmarks/ubuntu xenial main\n'
+            '# deb-src https://private-ppa.launchpad.net/'
+            'ubuntu-advantage/security-benchmarks/ubuntu xenial main\n')
+        self.assertEqual(expected, self.cisaudit_repo_list.read_text())
+        self.assertEqual(
+            self.apt_auth_file.read_text(),
+            'machine private-ppa.launchpad.net/ubuntu-advantage/'
+            'security-benchmarks/ubuntu/'
+            ' login user password pass\n')
+        self.assertEqual(self.apt_auth_file.stat().st_mode, 0o100600)
+        cis_keyring = 'ubuntu-securitybenchmarks-keyring.gpg'
+        keyring_file = self.trusted_gpg_dir / cis_keyring
+        self.assertEqual('GPG key', keyring_file.read_text())
+        self.assertIn(
+            'Successfully installed the CIS audit tool.',
+            process.stdout)
+        # the apt-transport-https dependency is already installed
+        self.assertNotIn(
+            'Installing missing dependency apt-transport-https',
+            process.stdout)
+
+    def test_enable_cisaudit_auth_if_other_entries(self):
+        """Existing auth.conf entries are preserved."""
+        auth = 'machine example.com login user password pass\n'
+        self.apt_auth_file.write_text(auth)
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(0, process.returncode)
+        self.assertIn(auth, self.apt_auth_file.read_text())
+
+    def test_enable_cisaudit_install_apt_transport_https(self):
+        """enable-cisaudit installs apt-transport-https if needed."""
+        self.apt_method_https.unlink()
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(0, process.returncode)
+        self.assertIn(
+            'Installing missing dependency apt-transport-https',
+            process.stdout)
+
+    def test_enable_cisaudit_install_apt_transport_https_fails(self):
+        """Stderr is printed if apt-transport-https install fails."""
+        self.apt_method_https.unlink()
+        self.make_fake_binary('apt-get', command='echo failed >&2; false')
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(1, process.returncode)
+        self.assertIn('failed', process.stderr)
+
+    def test_enable_cisaudit_install_ca_certificates(self):
+        """enable-cisaudit installs ca-certificates if needed."""
+        self.ca_certificates.unlink()
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(0, process.returncode)
+        self.assertIn(
+            'Installing missing dependency ca-certificates',
+            process.stdout)
+
+    def test_enable_cisaudit_install_ca_certificates_fails(self):
+        """Stderr is printed if ca-certificates install fails."""
+        self.ca_certificates.unlink()
+        self.make_fake_binary('apt-get', command='echo failed >&2; false')
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(1, process.returncode)
+        self.assertIn('failed', process.stderr)
+
+    def test_enable_cisaudit_missing_token(self):
+        """The token must be specified when using enable-cisaudit."""
+        process = self.script('enable-cisaudit')
+        self.assertEqual(3, process.returncode)
+        self.assertIn(
+            'Invalid token, it must be in the form "user:password"',
+            process.stderr)
+
+    def test_enable_cisaudit_invalid_token_format(self):
+        """The cisaudit token must be specified as "user:password"."""
+        process = self.script('enable-cisaudit', 'foo-bar')
+        self.assertEqual(3, process.returncode)
+        self.assertIn(
+            'Invalid token, it must be in the form "user:password"',
+            process.stderr)
+
+    def test_enable_cisaudit_invalid_token(self):
+        """If token is invalid, an error is returned."""
+        message = (
+            'E: Failed to fetch https://esm.ubuntu.com/'
+            '  401  Unauthorized [IP: 1.2.3.4]')
+        self.make_fake_binary(
+            'apt-helper', command='echo "{}"; exit 1'.format(message))
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(3, process.returncode)
+        self.assertIn('Checking token... ERROR', process.stdout)
+        self.assertIn('Invalid token', process.stderr)
+
+    def test_enable_cisaudit_error_checking_token(self):
+        """If token check fails, an error is returned."""
+        message = (
+            'E: Failed to fetch https://esm.ubuntu.com/'
+            '  404  Not Found [IP: 1.2.3.4]')
+        self.make_fake_binary(
+            'apt-helper', command='echo "{}"; exit 1'.format(message))
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(3, process.returncode)
+        self.assertIn('Checking token... ERROR', process.stdout)
+        self.assertIn(
+            'Failed checking token (404  Not Found [IP: 1.2.3.4])',
+            process.stderr)
+
+    def test_enable_cisaudit_skip_token_check_no_helper(self):
+        """If apt-helper is not found, the token check is skipped."""
+        self.apt_helper.unlink()
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(0, process.returncode)
+        self.assertIn('Checking token... SKIPPED', process.stdout)
+
+    def test_enable_cisaudit_only_supported_on_xenial(self):
+        """The enable-cisaudit option fails if not on Xenial."""
+        self.SERIES = 'zesty'
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(4, process.returncode)
+        self.assertIn(
+            'Canonical CIS 16.04 Benchmark Audit Tool '
+            'is not supported on zesty',
+            process.stderr)
+
+    def test_unsupported_on_i686(self):
+        """CISAudit is unsupported on i686 arch."""
+        self.ARCH = 'i686'
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(7, process.returncode)
+        self.assertIn(
+            'Sorry, but Canonical CIS 16.04 Benchmark Audit Tool '
+            'is not supported on i686',
+            process.stderr)
+
+    def test_unsupported_on_arm64(self):
+        """CISAudit is unsupported on arm64 arch."""
+        self.ARCH = 'arm64'
+        process = self.script('enable-cisaudit', 'user:pass')
+        self.assertEqual(7, process.returncode)
+        self.assertIn(
+            'Sorry, but Canonical CIS 16.04 Benchmark Audit Tool '
+            'is not supported on arm64',
+            process.stderr)

--- a/tests/test_cisaudit.py
+++ b/tests/test_cisaudit.py
@@ -183,5 +183,5 @@ class CISAUDITTest(UbuntuAdvantageTest):
         process = self.script('disable-cisaudit')
         self.assertEqual(8, process.returncode)
         self.assertIn(
-            'Canonical CIS Benchmark 16.04 Audit Tool is not enabled\n', 
+            'Canonical CIS Benchmark 16.04 Audit Tool is not enabled\n',
             process.stderr)

--- a/tests/test_cisaudit.py
+++ b/tests/test_cisaudit.py
@@ -164,7 +164,7 @@ class CISAUDITTest(UbuntuAdvantageTest):
             process.stderr)
 
     def test_disable_cisaudit(self):
-        """The disable-cisaudit option disables the security benchmarks repository."""
+        """The disable-cisaudit option disables security-benchmarks repo."""
         self.setup_cisaudit(enabled=True)
         other_auth = 'machine example.com login user password pass\n'
         self.apt_auth_file.write_text(other_auth)
@@ -172,14 +172,16 @@ class CISAUDITTest(UbuntuAdvantageTest):
         self.assertEqual(0, process.returncode)
         self.assertFalse(self.cisaudit_repo_list.exists())
         # the keyring file is removed
-        keyring_file = self.trusted_gpg_dir / 'ubuntu-securitybenchmarks-keyring.gpg'
+        cis_keyring = 'ubuntu-securitybenchmarks-keyring.gpg'
+        keyring_file = self.trusted_gpg_dir / cis_keyring
         self.assertFalse(keyring_file.exists())
         # credentials are removed
         self.assertEqual(self.apt_auth_file.read_text(), other_auth)
 
     def test_disable_cisaudit_fails_already_disabled(self):
-        """If the security benchmarks repo is not enabled, disable-cisaudit returns an error."""
+        """If security-benchmarks repo is not enabled, disable fails."""
         process = self.script('disable-cisaudit')
         self.assertEqual(8, process.returncode)
         self.assertIn(
-            'Canonical CIS Benchmark 16.04 Audit Tool is not enabled\n', process.stderr)
+            'Canonical CIS Benchmark 16.04 Audit Tool is not enabled\n', 
+            process.stderr)

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -189,5 +189,9 @@ class UbuntuAdvantageTest(TestWithFixtures):
 
     def setup_cisaudit(self, enabled=False):
         """Setup the CISAudit repository."""
-        self.make_fake_binary(
-            'dpkg-query', command='[ $2 != cisbenchmark-16.04 ]')
+        if enabled is True:
+            self.make_fake_binary(
+            'dpkg-query', command='[ $2 = ubuntu-cisbenchmark-16.04 ]')
+        else:
+            self.make_fake_binary(
+            'dpkg-query', command='[ $2 != ubuntu-cisbenchmark-16.04 ]')

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -58,6 +58,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.fips_updates_repo_list = Path(
             self.tempdir.join('fips-updates-repo.list'))
         self.cc_repo_list = Path(self.tempdir.join('cc-repo.list'))
+        self.cisaudit_repo_list = Path(self.tempdir.join('cisaudit-repo.list'))
         self.fips_repo_preferences = Path(
             self.tempdir.join('preferences-fips'))
         self.fips_updates_repo_preferences = Path(
@@ -84,6 +85,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
         (self.keyrings_dir / 'ubuntu-fips-updates-keyring.gpg').write_text(
             'GPG key')
         (self.keyrings_dir / 'ubuntu-cc-keyring.gpg').write_text('GPG key')
+        (self.keyrings_dir /
+            'ubuntu-securitybenchmarks-keyring.gpg').write_text('GPG key')
         self.cpuinfo.write_text('flags\t\t: fpu apic')
         self.make_fake_binary('apt-get')
         self.make_fake_binary('apt-helper')
@@ -120,6 +123,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'FIPS_REPO_LIST': str(self.fips_repo_list),
             'FIPS_UPDATES_REPO_LIST': str(self.fips_updates_repo_list),
             'CC_PROVISIONING_REPO_LIST': str(self.cc_repo_list),
+            'CISAUDIT_REPO_LIST': str(self.cisaudit_repo_list),
             'FIPS_BOOT_CFG': str(self.boot_cfg),
             'FIPS_BOOT_CFG_DIR': str(self.etc_dir),
             'FIPS_ENABLED_FILE': str(self.fips_enabled_file),
@@ -182,3 +186,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
         """Setup the CC repository."""
         self.make_fake_binary(
             'dpkg-query', command='[ $2 != ubuntu-commoncriteria ]')
+
+    def setup_cisaudit(self, enabled=False):
+        """Setup the CISAudit repository."""
+        self.make_fake_binary(
+            'dpkg-query', command='[ $2 != cisbenchmark-16.04 ]')

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -191,7 +191,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         """Setup the CISAudit repository."""
         if enabled is True:
             self.make_fake_binary(
-            'dpkg-query', command='[ $2 = ubuntu-cisbenchmark-16.04 ]')
+                'dpkg-query', command='[ $2 = ubuntu-cisbenchmark-16.04 ]')
         else:
             self.make_fake_binary(
-            'dpkg-query', command='[ $2 != ubuntu-cisbenchmark-16.04 ]')
+                'dpkg-query', command='[ $2 != ubuntu-cisbenchmark-16.04 ]')

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -4,7 +4,7 @@
 SCRIPTNAME=$(basename "$0")
 
 # Services managed by the script (in alphabetical order)
-SERVICES="cc-provisioning esm fips livepatch"
+SERVICES="cc-provisioning esm fips livepatch cisaudit"
 
 # system details
 SERIES=${SERIES:-$(lsb_release -cs)}
@@ -88,6 +88,9 @@ Commands:
  enable-cc-provisioning <TOKEN>    enable the commoncriteria PPA repository and
                                    install the ubuntu-commoncriteria .DEB package
  disable-cc-provisioning           currently not supported
+ enable-cisaudit                   enable the security benchmarks PPA repository
+                                   and install the ubuntu-securityguides .DEB
+                                   package.
 EOF
     error_exit invalid_command
 }

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -89,8 +89,9 @@ Commands:
                                    install the ubuntu-commoncriteria .DEB package
  disable-cc-provisioning           currently not supported
  enable-cisaudit                   enable the security benchmarks PPA repository
-                                   and install the ubuntu-securityguides .DEB
-                                   package.
+                                   and install the ubuntu-cisbenchmark-16.04 DEB package.
+ disable-cisaudit                  disable the security benchmarks PPA repository
+                                   and uninstall the ubuntu-cisbenchmark-16.04 DEB package.
 EOF
     error_exit invalid_command
 }

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -101,10 +101,16 @@ package which has the common criteria artifacts. The artifacts include a
 configure script, a tarball with additional packages and post install scripts
 and an evaluated configuration guide. The artifacts will be installed in
 /usr/lib/common-criteria directory.
+.SH CIS (Canonical CIS Audit tooling)
+Enable CIS Auditing PPA and install CIS audit tool package
 .TP
 .B
-disable-cc-provisioning
-Disabling common criteria provisioning is not supported
+enable-cisaudit \fItoken\fR
+Enables the Security Benchmarks PPA, installs the ubuntu-cisbenchmark-16.04
+package which has the CIS Audit tooling files. They include the xccdf and xml
+files and scripts to check compliance against the CIS 16.04 benchmark. The
+files will be installed in /usr/lib/ubuntu-securityguides/cisbenchmark-16.04.
+The documentation for the tool is available in /usr/share/doc/cisbenchmark-16.04.
 .SH EXIT STATUS
 .TP
 .B

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -101,6 +101,10 @@ package which has the common criteria artifacts. The artifacts include a
 configure script, a tarball with additional packages and post install scripts
 and an evaluated configuration guide. The artifacts will be installed in
 /usr/lib/common-criteria directory.
+.TP
+.B
+disable-cc-provisioning
+Disabling common criteria provisioning is not supported
 .SH CIS (Canonical CIS Audit tooling)
 Enable CIS Auditing PPA and install CIS audit tool package
 .TP
@@ -109,8 +113,15 @@ enable-cisaudit \fItoken\fR
 Enables the Security Benchmarks PPA, installs the ubuntu-cisbenchmark-16.04
 package which has the CIS Audit tooling files. They include the xccdf and xml
 files and scripts to check compliance against the CIS 16.04 benchmark. The
-files will be installed in /usr/lib/ubuntu-securityguides/cisbenchmark-16.04.
-The documentation for the tool is available in /usr/share/doc/cisbenchmark-16.04.
+files will be installed in
+/usr/share/ubuntu-securityguides/ubuntu-cisbenchmark-16.04.
+The documentation for the tool is available in
+/usr/share/doc/ubuntu-cisbenchmark-16.04.
+.TP
+.B
+disable-cisaudit
+Disables the security benchmarks PPA repository and removes the
+ubuntu-cisbenchmark-16.04 DEB package installed on the machine.
 .SH EXIT STATUS
 .TP
 .B


### PR DESCRIPTION
The patchset introduces new flags enable-cisaudit and disable-cisaudit to
install automated tooling package for cis auditing on a machine running xenial. 
The new flag enable-cisaudit enables the security-benchmarks
PPA and installs the cis audit tooling package and the flag disable-cisaudit uninstalls
the cis audit tooling package, removes the repository and clears the apt entries.

Signed-off-by: Vineetha Kamath <vineetha.hari.pai@canonical.com>