### PR TITLE
Add support for disable-cc-provisioning #151

### DIFF
--- a/modules/service-cc.sh
+++ b/modules/service-cc.sh
@@ -33,11 +33,24 @@ cc_provisioning_enable() {
     check_result apt_get install $CC_PROVISIONING_UBUNTU_COMMONCRITERIA
 
     echo "Successfully prepared this machine to host the Common Criteria artifacts."
-    echo "Please follow instructions in /usr/lib/common-criteria/README to configure EAL2 on the target machine(s)."
+    echo "Please follow instructions in /usr/share/doc/ubuntu-commoncriteria/README to configure EAL2 on the target machine(s)."
 }
 
 cc_provisioning_disable() {
-    not_supported 'Disabling Common Criteria EAL2 Provisioning'
+    if [ -f "$CC_PROVISIONING_REPO_LIST" ]; then
+        apt_remove_repo "$CC_PROVISIONING_REPO_LIST" "$CC_PROVISIONING_REPO_URL" \
+                        "$APT_KEYS_DIR/$CC_PROVISIONING_REPO_KEY_FILE"
+        echo -n 'Running apt-get update... '
+        check_result apt_get update
+        echo 'Canonical Common Criteria EAL2 Provisioning Disabled.'
+    else
+        echo 'Canonical Common Criteria EAL2 Provisioning is not Enabled.'
+    fi
+
+    if apt_is_package_installed $CC_PROVISIONING_UBUNTU_COMMONCRITERIA; then
+        check_result apt_get remove $CC_PROVISIONING_UBUNTU_COMMONCRITERIA
+        echo 'Canonical Common Criteria EAL2 Artifacts Removed.'
+    fi
 }
 
 cc_provisioning_is_enabled() {

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -184,8 +184,12 @@ class UbuntuAdvantageTest(TestWithFixtures):
 
     def setup_cc(self, enabled=False):
         """Setup the CC repository."""
-        self.make_fake_binary(
-            'dpkg-query', command='[ $2 != ubuntu-commoncriteria ]')
+        if enabled is True:
+            self.make_fake_binary(
+                'dpkg-query', command='[ $2 = ubuntu-commoncriteria ]')
+        else:
+            self.make_fake_binary(
+                'dpkg-query', command='[ $2 != ubuntu-commoncriteria ]')
 
     def setup_cisaudit(self, enabled=False):
         """Setup the CISAudit repository."""

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -64,6 +64,7 @@ Currently available are:
 - Canonical FIPS 140-2 Non-Certified Module Updates
 - Canonical Livepatch Service (https://www.ubuntu.com/server/livepatch)
 - Canonical Common Criteria EAL2 certification artifacts provisioning
+- Canonical CIS Ubuntu Benchmark Audit tool
 
 Commands:
  version                           show the tool version
@@ -86,12 +87,15 @@ Commands:
  disable-livepatch [-r]            disable the Livepatch service. With "-r", the
                                    canonical-livepatch snap will also be removed
  enable-cc-provisioning <TOKEN>    enable the commoncriteria PPA repository and
-                                   install the ubuntu-commoncriteria .DEB package
- disable-cc-provisioning           currently not supported
- enable-cisaudit                   enable the security benchmarks PPA repository
-                                   and install the ubuntu-cisbenchmark-16.04 DEB package.
+                                   install the ubuntu-commoncriteria DEB package
+ disable-cc-provisioning           disable the commoncriteria PPA repository and
+                                   remove the ubuntu-commoncriteria DEB package
+ enable-cisaudit <TOKEN>           enable the security benchmarks PPA repository
+                                   and install the ubuntu-cisbenchmark-16.04 DEB
+                                   package.
  disable-cisaudit                  disable the security benchmarks PPA repository
-                                   and uninstall the ubuntu-cisbenchmark-16.04 DEB package.
+                                   and uninstall the ubuntu-cisbenchmark-16.04 DEB
+                                   package.
 EOF
     error_exit invalid_command
 }

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -98,13 +98,16 @@ Enable Common Criteria PPA and install Common Criteria EAL2 artifacts
 enable-cc-provisioning \fItoken\fR
 Enables the Commoncriteria PPA repository, installs the ubuntu-commoncriteria
 package which has the common criteria artifacts. The artifacts include a
-configure script, a tarball with additional packages and post install scripts
-and an evaluated configuration guide. The artifacts will be installed in
-/usr/lib/common-criteria directory.
+configure script, a tarball with additional packages and post install scripts.
+The artifacts will be installed in /usr/lib/common-criteria directory. The
+evaluated configuration guide and README instructions on how to set up a
+system to be Common Criteria compliant are available in
+/usr/share/doc/ubuntu-commoncriteria directory.
 .TP
 .B
 disable-cc-provisioning
-Disabling common criteria provisioning is not supported
+Disables the commoncriteria PPA repository and removes the ubuntu-commoncriteria
+DEB package.
 .SH CIS (Canonical CIS Audit tooling)
 Enable CIS Auditing PPA and install CIS audit tool package
 .TP


### PR DESCRIPTION
Signed-off-by: Vineetha Kamath <vineetha.hari.pai@canonical.com>

This patch-set adds support for 'disable-cc-provisioning' command to disable provisioning a machine for Common Criteria artifacts installation. It removes the Common Criteria PPA repository and also removes the ubuntu-commoncriteria DEB package installed on the machine. 