### PR TITLE
Fix shellcheck SC2244

### DIFF
--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -112,7 +112,7 @@ livepatch_disable() {
 
     echo 'Disabling Livepatch...'
     canonical-livepatch disable
-    if [ "$remove_snap" ]; then
+    if [ -n "$remove_snap" ]; then
         echo 'Removing the canonical-livepatch snap...'
         snap remove canonical-livepatch
     else

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -41,7 +41,7 @@ print_status() {
     local service="$1"
 
     local services="$SERVICES"
-    if [ "$service" ]; then
+    if [ -n "$service" ]; then
         name_in_list "${service//_/-}" "$SERVICES" || error_exit invalid_command
         services="$service"
     fi
@@ -107,7 +107,7 @@ main() {
     local service
     service=$(service_from_command "$command")
     # if the command contains a service name, check that it's valid
-    if [ "$service" ] && ! name_in_list "$service" "$SERVICES" \
+    if [ -n "$service" ] && ! name_in_list "$service" "$SERVICES" \
            && [ "$service" != "fips-updates" ]; then
         error_msg "Invalid command: \"$command\""
         usage


### PR DESCRIPTION
Use -n when checking if a variable was defined. Solves shellcheck SC2244.