### PR TITLE
Revert "Merge pull request #147 from panlinux/switch-kernel-for-lp"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,13 +2,11 @@ ubuntu-advantage-tools (18) UNRELEASED; urgency=medium
 
   * Have ua status cope with the additional livepatch of running a kernel
     that is not supported for livepatches.
-  * Have an option for enable-livepatch to install a compatible kernel if
-    needed.
 
-  [ Vineetha Kamath ]
+    [ Vineetha Kamath ]
   * Add support to common criteria EAL2 artifacts installation #144
 
- -- Andreas Hasenack <andreas@canonical.com>  Thu, 21 Jun 2018 14:30:57 -0300
+ -- Andreas Hasenack <andreas@canonical.com>  Thu, 24 May 2018 17:26:25 -0300
 
 ubuntu-advantage-tools (17) bionic; urgency=medium
 

--- a/modules/service-livepatch.sh
+++ b/modules/service-livepatch.sh
@@ -3,92 +3,25 @@
 LIVEPATCH_SERVICE_TITLE="Canonical Livepatch"
 LIVEPATCH_SUPPORTED_SERIES="trusty xenial bionic"
 LIVEPATCH_SUPPORTED_ARCHS="x86_64"
-LIVEPATCH_FALLBACK_KERNEL="linux-image-generic"
-
-_livepatch_install_supported_kernel() {
-    if apt_is_package_installed "${LIVEPATCH_FALLBACK_KERNEL}"; then
-        return 0
-    fi
-    echo 'A Livepatch compatible kernel will be installed.'
-    echo -n 'Running apt-get update... '
-    check_result apt_get update
-    echo -n "Installing ${LIVEPATCH_FALLBACK_KERNEL}... "
-    check_result apt_get install "${LIVEPATCH_FALLBACK_KERNEL}"
-}
-
-_livepatch_try_enable() {
-    local token="$1"
-    local allow_kernel_change="$2"
-    local output=""
-    local result=0
-    local disabled_reason=""
-
-    output=$(canonical-livepatch enable "$token" 2>&1) || result=$?
-    if [ "${result}" -eq "0" ]; then
-        echo "${output}"
-        return 0
-    fi
-    # ok, we failed, why?
-    disabled_reason=$(livepatch_disabled_reason "${output}")
-    if echo "${disabled_reason}" | grep -q "unsupported kernel"; then
-        echo -n "Your running kernel ${KERNEL_VERSION} is not supported by "
-        echo 'Livepatch.'
-        if [ "${allow_kernel_change}" = "yes" ]; then
-            _livepatch_install_supported_kernel
-            echo 'A new kernel was installed to support Livepatch.'
-            echo 'Please reboot into it and then run the enable command again:'
-            echo
-            echo "sudo $SCRIPTNAME enable-livepatch $token"
-        else
-            echo
-            echo -n 'If you want to automatically install a Livepatch supported '
-            echo 'kernel, please run:'
-            echo -n "sudo $SCRIPTNAME enable-livepatch $token "
-            echo '--allow-kernel-change'
-        fi
-        error_exit livepatch_unsupported_kernel
-    else
-        error_msg "${output}"
-        exit ${result}
-    fi
-}
-
-_old_kernel_message() {
-    local token="$1"
-
-    echo
-    echo "Your currently running kernel ($KERNEL_VERSION) is too old to"
-    echo "support snaps. Version 4.4.0 or higher is needed."
-    echo
-    echo "Please reboot your system into a supported kernel version"
-    echo "and run the following command one more time to complete the"
-    echo "installation:"
-    echo
-    echo "sudo $SCRIPTNAME enable-livepatch $token"
-}
 
 livepatch_enable() {
     local token="$1"
-    local allow_kernel_change="no"
-
-    shift
-    local extra_arg="$*"
-    if [ -n "$extra_arg" ]; then
-        if [ "$extra_arg" = "--allow-kernel-change" ]; then
-            allow_kernel_change="yes"
-        else
-            error_msg "Unknown option for enable-livepatch: \"$extra_arg\""
-            usage
-        fi
-    fi
 
     _livepatch_install_prereqs
     if ! livepatch_is_enabled; then
         if check_snapd_kernel_support; then
             echo 'Enabling Livepatch with the given token, stand by...'
-            _livepatch_try_enable "${token}" "${allow_kernel_change}"
+            canonical-livepatch enable "$token"
         else
-            _old_kernel_message "${token}"
+            echo
+            echo "Your currently running kernel ($KERNEL_VERSION) is too old to"
+            echo "support snaps. Version 4.4.0 or higher is needed."
+            echo
+            echo "Please reboot your system into a supported kernel version"
+            echo "and run the following command one more time to complete the"
+            echo "installation:"
+            echo
+            echo "sudo $SCRIPTNAME enable-livepatch $token"
             error_exit kernel_too_old
         fi
     else
@@ -130,13 +63,8 @@ livepatch_disabled_reason() {
     local output
     local result=0
     local unsupported_kernel_msg="is not eligible for livepatch updates"
-    local message_to_check="$1"
 
-    if [ -z "${message_to_check}" ]; then
-        output=$(canonical-livepatch status 2>&1) || result=$?
-    else
-        output="${message_to_check}"
-    fi
+    output=$(canonical-livepatch status 2>&1) || result=$?
     if echo "${output}" | grep -q "${unsupported_kernel_msg}"; then
         echo " (unsupported kernel)"
     fi

--- a/modules/service.sh
+++ b/modules/service.sh
@@ -11,18 +11,12 @@ service_from_command() {
 service_enable() {
     local service="$1"
     local token="$2"
-    if [ -n "$token" ]; then
-        shift 2
-    else
-        shift
-    fi
-    local opts="$*"
 
     service_check_user
     service_check_support "$service"
     _service_check_enabled "$service" || error_exit service_already_enabled
     "${service}_validate_token" "$token" || error_exit invalid_token
-    "${service}_enable" "$token" "$opts"
+    "${service}_enable" "$token"
 }
 
 service_disable() {

--- a/modules/utils.sh
+++ b/modules/utils.sh
@@ -16,7 +16,6 @@ error_exit() {
         [service_already_enabled]=6
         [arch_not_supported]=7
         [service_already_disabled]=8
-        [livepatch_unsupported_kernel]=9
     )
     exit "${codes[$code]}"
 }

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -30,14 +30,6 @@ EOF
 fi
 """
 
-# the error string is made up
-LIVEPATCH_UNKNOWN_ERROR = """
-cat <<EOF
-2018-06-18 17:46:11 something wicked happened here
-EOF
-exit 1
-"""
-
 # regardless of the command, canonical-livepatch will always exit with
 # status 1 and a message like this
 LIVEPATCH_UNSUPPORTED_KERNEL = """

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -79,11 +79,7 @@ Commands:
                                    repository and install updates. With an
                                    optional "-y" the user prompt will be
                                    bypassed.
- enable-livepatch <TOKEN> [--allow-kernel-change]
-                                   enable the Livepatch service. If the
-                                   --allow-kernel-change option is provided, a
-                                   Livepatch compatible kernel may be installed
-                                   if needed.
+ enable-livepatch <TOKEN>          enable the Livepatch service
  disable-livepatch [-r]            disable the Livepatch service. With "-r", the
                                    canonical-livepatch snap will also be removed
  enable-cc-provisioning <TOKEN>    enable the commoncriteria PPA repository and

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -79,12 +79,9 @@ Managed live kernel patching. For more information, visit
 https://www.ubuntu.com/server/livepatch
 .TP
 .B
-enable-livepatch \fItoken\fR [\fB\-\-allow\-kernel\-change\fR]
+enable-livepatch \fI<token>\fR
 Enable the Livepatch service. The \fItoken\fR can be obtained by visiting
-https://ubuntu.com/livepatch. If a Livepatch incompatible kernel is running,
-the installation will fail unless \fB\-\-allow\-kernel\-change\fR is given.
-With this option, a Livepatch compatible kernel will be selected and installed
-if needed.
+https://ubuntu.com/livepatch
 .TP
 .B
 disable-livepatch \fR[\fB\-r\fR]
@@ -162,9 +159,5 @@ The requested service is not supported on the current architecture
 .B
 8
 The requested service is already disabled
-.TP
-.B
-9
-The running kernel does not support Livepatch
 .TP
 If apt commands run by the tool fail, the exit status from apt is returned.


### PR DESCRIPTION
This reverts commit 77606776c83d118264d4bc7efe898b937d28febd, reversing
changes made to df02ea5f24e43cc395df878269895b2ad8d6cb0d.

Dropping the switch-kernel-for-lp merge, as that feature is incomplete and
the way forward is not clear. What's missing is a way to keep the machine on the selected kernel, for the next boot and future kernel upgrades.