### PR TITLE
V18 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Currently it supports the following:
 - [Canonical Livepatch](https://www.ubuntu.com/server/livepatch) service for managed live kernel patching.
 - Canonical FIPS 140-2 Certified Modules. Install Configure and Enable FIPS modules.
 - Canonical Common Criteria EAL2 certification artifacts provisioning
+- Canonical CIS Ubuntu Benchmark Audit tool
 
 Run 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -13,10 +13,13 @@ ubuntu-advantage-tools (18) disco; urgency=medium
 
 ubuntu-advantage-tools (17) bionic; urgency=medium
 
-  * New upstream release
-    - added enable-fips-updates command. This command enables the fips-updates
+  * New upstream release (LP: #1759280):
+    - Added enable-fips-updates command. This command enables the fips-updates
       repository to install updates to FIPS modules. The updated modules from
       fips-updates repository are non-certified.
+    - Add repository pinning for FIPS packages
+    - Check that all prerequisite packages are installed when enabling FIPS
+    - Support returning the status for a single service
 
  -- Andreas Hasenack <andreas@canonical.com>  Wed, 21 Mar 2018 14:20:04 -0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,15 @@
-ubuntu-advantage-tools (18) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (18) disco; urgency=medium
 
-  * Have ua status cope with the additional livepatch of running a kernel
-    that is not supported for livepatches.
+  [ Andreas Hasenack ]
+  * Have ua status cope with the additional livepatch status of running a
+    kernel that is not supported for livepatches.
 
-    [ Vineetha Kamath ]
+  [ Vineetha Kamath ]
   * Add support to common criteria EAL2 artifacts installation #144
+  * Add new flag enable-cisaudit to support cis audit
+  * Add support for disable-cc-provisioning
 
- -- Andreas Hasenack <andreas@canonical.com>  Thu, 24 May 2018 17:26:25 -0300
+ -- Andreas Hasenack <andreas@canonical.com>  Mon, 14 Jan 2019 16:39:31 -0200
 
 ubuntu-advantage-tools (17) bionic; urgency=medium
 

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -82,14 +82,14 @@ Commands:
  enable-livepatch <TOKEN>          enable the Livepatch service
  disable-livepatch [-r]            disable the Livepatch service. With "-r", the
                                    canonical-livepatch snap will also be removed
- enable-cc-provisioning <TOKEN>    enable the commoncriteria PPA repository and
+ enable-cc-provisioning <TOKEN>    enable the commoncriteria repository and
                                    install the ubuntu-commoncriteria DEB package
- disable-cc-provisioning           disable the commoncriteria PPA repository and
+ disable-cc-provisioning           disable the commoncriteria repository and
                                    remove the ubuntu-commoncriteria DEB package
- enable-cisaudit <TOKEN>           enable the security benchmarks PPA repository
+ enable-cisaudit <TOKEN>           enable the security benchmarks repository
                                    and install the ubuntu-cisbenchmark-16.04 DEB
                                    package.
- disable-cisaudit                  disable the security benchmarks PPA repository
+ disable-cisaudit                  disable the security benchmarks repository
                                    and uninstall the ubuntu-cisbenchmark-16.04 DEB
                                    package.
 EOF


### PR DESCRIPTION
This updates master with what was uploaded to ubuntu disco as v18. Besides syncing `debian/changelog` (the v17 changelog entries were incomplete), the following two changes were done in the ubuntu upload:
- Mention the CIS audit tool in the README.md file
- Remove the word "PPA" from the help output, as it's a needless implementation detail.

The last one can be considered a follow-up to PR #153 